### PR TITLE
Replaced EZCDF with NetCDF F90 calls

### DIFF
--- a/Makefile.def
+++ b/Makefile.def
@@ -1,34 +1,34 @@
 ifeq ($(COMPILER),ICC)
-     FFLAGS = -cpp -O2 -stand f08 -real-size 64 -auto-scalar $(EZCDF_FLAGS)
+     FFLAGS = -cpp -O2 -stand f08 -real-size 64 -auto-scalar $(NETCDF_FLAGS)
      LDFLAGS = -cpp
      DFFLAGS = -g -traceback -check all -warn all
      SFFLAGS = -fpic
      SLDFLAGS = -shared
-     CXXFLAGS = -O2 -std=c++11 $(EZCDF_FLAGS)
+     CXXFLAGS = -O2 -std=c++11 $(NETCDF_FLAGS)
      CXXLIBS = -lifcore
      CXXLDFLAGS =
 
 else ifeq ($(COMPILER),PGC)
-     FFLAGS = -cpp -fast -r8 $(EZCDF_FLAGS) -D_PGC
+     FFLAGS = -cpp -fast -r8 $(NETCDF_FLAGS) -D_PGC
      LDFLAGS = -cpp
      DFFLAGS = -g -traceback -Mbounds
      SFFLAGS = -fpic
      SLDFLAGS = -shared
-     CXXFLAGS = -O2 -mp -std=c++11 $(EZCDF_FLAGS)
+     CXXFLAGS = -O2 -mp -std=c++11 $(NETCDF_FLAGS)
      CXXLIBS = -lstdc++ -lgfortran
      CXXLDFLAGS =
 
 else
      COMPILER = gfortran
-     FFLAGS = -cpp -dM -O2 -std=f2008 -fdefault-real-8 -ffpe-trap=invalid,zero,overflow $(EZCDF_FLAGS)
+     FFLAGS = -cpp -dM -O2 -std=f2008 -fdefault-real-8 -ffpe-trap=invalid,zero,overflow $(NETCDF_FLAGS)
      LDFLAGS = -cpp
      DFFLAGS = -Og -Wall
      SFFLAGS = -fpic
      SLDFLAGS = -shared
-     CXXFLAGS = -O2 -std=c++11 $(EZCDF_FLAGS)
+     CXXFLAGS = -O2 -std=c++11 $(NETCDF_FLAGS)
      CXXLIBS = -lstdc++ -lgfortran
      CXXLDFLAGS =
 endif
 
-FLIBS = $(L_EZCDF)
-FINCL = $(I_EZCDF)
+FLIBS = $(L_NETCDF)
+FINCL = $(I_NETCDF)

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Test programs are included in the source directories.
 
 See the sample configuration used at PPPL: pppl-bashrc
 
-If you want to use the NETCDF I/O capability with EZspline then you must have the EZCDF library installed. It is also on github: https://github.com/transp/ezcdf. See the PPPL configuration file for how to include EZCDF with PSPLINE.
-
 
 ## Build
 

--- a/czspline/czspline_1d.f90
+++ b/czspline/czspline_1d.f90
@@ -133,7 +133,7 @@ contains
     return
   end subroutine czspline_free1
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   subroutine czspline_save1(cname, ier) bind(C)
     use ezspline
     implicit none

--- a/czspline/czspline_2d.f90
+++ b/czspline/czspline_2d.f90
@@ -155,7 +155,7 @@ contains
     return
   end subroutine czspline_free2
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   ! save to file
   subroutine czspline_save2(cname, ier) bind(C)
     use ezspline

--- a/czspline/czspline_3d.f90
+++ b/czspline/czspline_3d.f90
@@ -170,7 +170,7 @@ contains
     return
   end subroutine czspline_free3
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   ! save to file
   subroutine czspline_save3(cname, ier) bind(C)
     use ezspline

--- a/czspline/czspline_test.cc
+++ b/czspline/czspline_test.cc
@@ -77,7 +77,7 @@ void test1d() {
     error_array += std::abs(g[i] - y[i]*y[i]*y[i]);
   error_array /= double(m);
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   // save to file
   char fname[10] = "test1d.nc";
   czspline_save1(fname, &ier);
@@ -88,10 +88,11 @@ void test1d() {
   czspline_free1(&ier);
   assert(ier == 0);
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   // load from file
   czspline_load1(fname, &ier);
   assert(ier == 0);
+
   czspline_free1(&ier);
   assert(ier == 0);
 #endif
@@ -200,19 +201,18 @@ void test2d() {
   }
   error_array /= double(m1 * m2);
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   // save to file
   char fname[10] = "test2d.nc";
   czspline_save2(fname, &ier);
   assert(ier == 0);
-
 #endif
 
   // clean up
   czspline_free2(&ier);
   assert(ier == 0);
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   // load from file
   czspline_load2(fname, &ier);
   assert(ier == 0);
@@ -361,7 +361,7 @@ void test3d() {
   }
   error_array /= double(m1 * m2 * m3);
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   // save to file
   char fname[10] = "test3d.nc";
   czspline_save3(fname, &ier);
@@ -372,7 +372,7 @@ void test3d() {
   czspline_free3(&ier);
   assert(ier == 0);
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   // load from file
   czspline_load3(fname, &ier);
   assert(ier == 0);

--- a/ezspline/ezspline_2netcdf.f90
+++ b/ezspline/ezspline_2netcdf.f90
@@ -1,230 +1,238 @@
-#ifdef _EZCDF
+#ifdef _NETCDF
 
 subroutine EZspline_2NetCDF_array3(n1, n2, n3, x1, x2, x3, f, filename, ier)
   use psp_precision_mod, only: fp
   use EZspline_obj   
-  use EZcdf
+  use netcdf
   implicit none
-  integer, intent(in) :: n1, n2, n3
-  real(fp), intent(in) :: x1(:), x2(:), x3(:), f(:, :, :)
-  character(len=*), intent(in) :: filename
-  integer, intent(out) :: ier
-  integer ifail
+  integer,                    intent(in)  :: n1, n2, n3
+  real(fp), dimension(:),     intent(in)  :: x1, x2, x3
+  real(fp), dimension(:,:,:), intent(in)  :: f
+  character(len=*),           intent(in)  :: filename
+  integer,                    intent(out) :: ier
 
-  integer dimlens(3), ncid
+  integer, dimension(3) :: dimid_n
+  integer               :: varid_x1, varid_x2, varid_x3
+  integer               :: varid_f
+  integer               :: ncid
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'w')
-  if(ncid==0) then
-     ier = 34
-     return
-  end if
-  dimlens = (/ 1, 1, 1 /)
-  call cdfDefVar(ncid, 'n1', dimlens, 'INT', ifail)
-  call cdfDefVar(ncid, 'n2', dimlens, 'INT', ifail)
-  call cdfDefVar(ncid, 'n3', dimlens, 'INT', ifail)
-  dimlens = (/ n1, 1, 1 /)
-  call cdfDefVar(ncid, 'x1', dimlens, 'R8', ifail)
-  dimlens = (/ n2, 1, 1 /)
-  call cdfDefVar(ncid, 'x2', dimlens, 'R8', ifail)
-  dimlens = (/ n3, 1, 1 /)
-  call cdfDefVar(ncid, 'x3', dimlens, 'R8', ifail)
-  dimlens = (/ n1, n2, n3 /)
-  call cdfDefVar(ncid, 'f', dimlens, 'R8', ifail)
-  if(ifail/=0) then
-     ier = 38 
-     return
-  end if
-  call cdfPutVar(ncid, 'n1', n1, ifail)
-  call cdfPutVar(ncid, 'n2', n2, ifail)
-  call cdfPutVar(ncid, 'n3', n3, ifail)
-  call cdfPutVar(ncid, 'x1', x1, ifail)
-  call cdfPutVar(ncid, 'x2', x2, ifail)
-  call cdfPutVar(ncid, 'x3', x3, ifail)
-  call cdfPutVar(ncid, 'f', f, ifail)
-  if(ifail/=0) then
-     ier = 35 
-     return
+  ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 33
+    return
   end if
 
-  call cdfCls(ncid)
+  ier = nf90_def_dim(ncid,'n1',n1,dimid_n(1))
+  if(ier.eq.NF90_NOERR) ier = nf90_def_dim(ncid,'n2',n2,dimid_n(2))
+  if(ier.eq.NF90_NOERR) ier = nf90_def_dim(ncid,'n3',n3,dimid_n(3))
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x1',NF90_DOUBLE,dimid_n(1),varid_x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x2',NF90_DOUBLE,dimid_n(2),varid_x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x3',NF90_DOUBLE,dimid_n(3),varid_x3)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'f',NF90_DOUBLE,dimid_n,varid_f)
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 34
+    return
+  end if
 
+  ier = nf90_put_var(ncid,varid_x1,x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_x2,x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_x3,x3)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_f,f)
+  if(ier.ne.NF90_NOERR) then
+    ier = 35
+    return
+  end if
+
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 36
+
+  return
 end subroutine EZspline_2NetCDF_array3
 
+
 subroutine EZspline_2NetCDF_array2(n1, n2, x1, x2, f, filename, ier)
+  use psp_precision_mod, only: fp
   use EZspline_obj   
-  use EZcdf
+  use netcdf
   implicit none
-  integer, intent(in) :: n1, n2
-  real(fp), intent(in) :: x1(:), x2(:), f(:,:)
-  character(len=*), intent(in) :: filename
-  integer, intent(out) :: ier
-  integer ifail
+  integer,                  intent(in)  :: n1, n2
+  real(fp), dimension(:),   intent(in)  :: x1, x2
+  real(fp), dimension(:,:), intent(in)  :: f
+  character(len=*),         intent(in)  :: filename
+  integer,                  intent(out) :: ier
 
-  integer dimlens(3), ncid
+  integer, dimension(2) :: dimid_n
+  integer               :: varid_x1, varid_x2
+  integer               :: varid_f
+  integer               :: ncid
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'w')
-  if(ncid==0) then
-     ier = 34
-     return
-  end if
-  dimlens = (/ 1, 1, 1 /)
-  call cdfDefVar(ncid, 'n1', dimlens, 'INT', ifail)
-  call cdfDefVar(ncid, 'n2', dimlens, 'INT', ifail)
-  dimlens = (/ n1, 1, 1 /)
-  call cdfDefVar(ncid, 'x1', dimlens, 'R8', ifail)
-  dimlens = (/ n2, 1, 1 /)
-  call cdfDefVar(ncid, 'x2', dimlens, 'R8', ifail)
-  dimlens = (/ n1, n2, 1 /)
-  call cdfDefVar(ncid, 'f', dimlens, 'R8', ifail)
-  if(ifail/=0) then
-     ier = 38 
-     return
+  ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 33
+    return
   end if
 
-  call cdfPutVar(ncid, 'n1', n1, ifail)
-  call cdfPutVar(ncid, 'n2', n2, ifail)
-  call cdfPutVar(ncid, 'x1', x1, ifail)
-  call cdfPutVar(ncid, 'x2', x2, ifail)
-  call cdfPutVar(ncid, 'f', f, ifail)
-  if(ifail/=0) then
-     ier = 35 
-     return
+  ier = nf90_def_dim(ncid,'n1',n1,dimid_n(1))
+  if(ier.eq.NF90_NOERR) ier = nf90_def_dim(ncid,'n2',n2,dimid_n(2))
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x1',NF90_DOUBLE,dimid_n(1),varid_x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x2',NF90_DOUBLE,dimid_n(2),varid_x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'f',NF90_DOUBLE,dimid_n,varid_f)
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 34
+    return
   end if
 
-  call cdfCls(ncid)
+  ier = nf90_put_var(ncid,varid_x1,x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_x2,x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_f,f)
+  if(ier.ne.NF90_NOERR) then
+    ier = 35
+    return
+  end if
 
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 36
+
+  return
 end subroutine EZspline_2NetCDF_array2
 
-subroutine EZspline_2NetCDF1(n1, x1, f, filename, ier)
+
+subroutine EZspline_2NetCDF_array1(n1, x1, f, filename, ier)
+  use psp_precision_mod, only: fp
   use EZspline_obj   
-  use EZcdf
+  use netcdf
   implicit none
-  integer, intent(in) :: n1
-  real(fp), intent(in) :: x1(:), f(:)
-  character(len=*), intent(in) :: filename
-  integer, intent(out) :: ier
-  integer ifail
+  integer,                intent(in)  :: n1
+  real(fp), dimension(:), intent(in)  :: x1
+  real(fp), dimension(:), intent(in)  :: f
+  character(len=*),       intent(in)  :: filename
+  integer,                intent(out) :: ier
 
-  integer dimlens(3), ncid
+  integer :: dimid_n1
+  integer :: varid_x1
+  integer :: varid_f
+  integer :: ncid
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'w')
-  if(ncid==0) then
-     ier = 34
-     return
-  end if
-  dimlens = (/ 1, 1, 1 /)
-  call cdfDefVar(ncid, 'n1', dimlens, 'INT', ifail)
-  dimlens = (/ n1, 1, 1 /)
-  call cdfDefVar(ncid, 'x1', dimlens, 'R8', ifail)
-  dimlens = (/ n1, 1, 1 /)
-  call cdfDefVar(ncid, 'f', dimlens, 'R8', ifail)
-  if(ifail/=0) then
-     ier = 38 
-     return
+  ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 33
+    return
   end if
 
-  call cdfPutVar(ncid, 'n1', n1, ifail)
-  call cdfPutVar(ncid, 'x1', x1, ifail)
-  call cdfPutVar(ncid, 'f', f, ifail)
-  if(ifail/=0) then
-     ier = 35 
-     return
+  ier = nf90_def_dim(ncid,'n1',n1,dimid_n1)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x1',NF90_DOUBLE,dimid_n1,varid_x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'f',NF90_DOUBLE,dimid_n1,varid_f)
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 34
+    return
   end if
 
-  call cdfCls(ncid)
-end subroutine EZspline_2NetCDF1
+  ier = nf90_put_var(ncid,varid_x1,x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_f,f)
+  if(ier.ne.NF90_NOERR) then
+    ier = 35
+    return
+  end if
+
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 36
+
+  return
+end subroutine EZspline_2NetCDF_array1
+
 
 subroutine EZspline_2NetCDF_cloud3(n, x1, x2, x3, f, filename, ier)
+  use psp_precision_mod, only: fp
   use EZspline_obj   
-  use EZcdf
+  use netcdf
   implicit none
-  integer, intent(in) :: n
-  real(fp), intent(in) :: x1(:), x2(:), x3(:), f(:)
-  character(len=*), intent(in) :: filename
-  integer, intent(out) :: ier
-  integer ifail
+  integer,                intent(in)  :: n
+  real(fp), dimension(:), intent(in)  :: x1, x2, x3, f
+  character(len=*),       intent(in)  :: filename
+  integer,                intent(out) :: ier
 
-  integer dimlens(3), ncid
+  integer :: dimid_n
+  integer :: varid_x1, varid_x2, varid_x3
+  integer :: varid_f
+  integer :: ncid
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'w')
-  if(ncid==0) then
-     ier = 34
-     return
-  end if
-  dimlens = (/ 1, 1, 1 /)
-  call cdfDefVar(ncid, 'n', dimlens, 'INT', ifail)
-  dimlens = (/ n, 1, 1 /)
-  call cdfDefVar(ncid, 'x1', dimlens, 'R8', ifail)
-  dimlens = (/ n, 1, 1 /)
-  call cdfDefVar(ncid, 'x2', dimlens, 'R8', ifail)
-  dimlens = (/ n, 1, 1 /)
-  call cdfDefVar(ncid, 'x3', dimlens, 'R8', ifail)
-  dimlens = (/ n, 1, 1 /)
-  call cdfDefVar(ncid, 'f', dimlens, 'R8', ifail)
-  if(ifail/=0) then
-     ier = 38 
-     return
+  ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 33
+    return
   end if
 
-  call cdfPutVar(ncid, 'n', n, ifail)
-  call cdfPutVar(ncid, 'x1', x1, ifail)
-  call cdfPutVar(ncid, 'x2', x2, ifail)
-  call cdfPutVar(ncid, 'x3', x3, ifail)
-  call cdfPutVar(ncid, 'f', f, ifail)
-  if(ifail/=0) then
-     ier = 35 
-     return
+  ier = nf90_def_dim(ncid,'n',n,dimid_n)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x1',NF90_DOUBLE,dimid_n,varid_x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x2',NF90_DOUBLE,dimid_n,varid_x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x3',NF90_DOUBLE,dimid_n,varid_x3)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'f',NF90_DOUBLE,dimid_n,varid_f)
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 34
+    return
   end if
 
-  call cdfCls(ncid)
+  ier = nf90_put_var(ncid,varid_x1,x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_x2,x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_x3,x3)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_f,f)
+  if(ier.ne.NF90_NOERR) then
+    ier = 35
+    return
+  end if
 
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 36
+
+  return
 end subroutine EZspline_2NetCDF_cloud3
 
 subroutine EZspline_2NetCDF_cloud2(n, x1, x2, f, filename, ier)
+  use psp_precision_mod, only: fp
   use EZspline_obj   
-  use EZcdf
+  use netcdf
   implicit none
-  integer, intent(in) :: n
-  real(fp), intent(in) :: x1(:), x2(:), f(:)
-  character(len=*), intent(in) :: filename
-  integer, intent(out) :: ier
-  integer ifail
+  integer,                intent(in)  :: n
+  real(fp), dimension(:), intent(in)  :: x1, x2
+  real(fp), dimension(:), intent(in)  :: f
+  character(len=*),       intent(in)  :: filename
+  integer,                intent(out) :: ier
 
-  integer dimlens(3), ncid
+  integer :: dimid_n
+  integer :: varid_x1, varid_x2
+  integer :: varid_f
+  integer :: ncid
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'w')
-  if(ncid==0) then
-     ier = 34
-     return
-  end if
-  dimlens = (/ 1, 1, 1 /)
-  call cdfDefVar(ncid, 'n', dimlens, 'INT', ifail)
-  dimlens = (/ n, 1, 1 /)
-  call cdfDefVar(ncid, 'x1', dimlens, 'R8', ifail)
-  dimlens = (/ n, 1, 1 /)
-  call cdfDefVar(ncid, 'x2', dimlens, 'R8', ifail)
-  dimlens = (/ n, 1, 1 /)
-  call cdfDefVar(ncid, 'f', dimlens, 'R8', ifail)
-  if(ifail/=0) then
-     ier = 38 
-     return
+  ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 33
+    return
   end if
 
-  call cdfPutVar(ncid, 'n', n, ifail)
-  call cdfPutVar(ncid, 'x1', x1, ifail)
-  call cdfPutVar(ncid, 'x2', x2, ifail)
-  call cdfPutVar(ncid, 'f', f, ifail)
-  if(ifail/=0) then
-     ier = 35 
-     return
+  ier = nf90_def_dim(ncid,'n',n,dimid_n)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x1',NF90_DOUBLE,dimid_n,varid_x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'x2',NF90_DOUBLE,dimid_n,varid_x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_def_var(ncid,'f',NF90_DOUBLE,dimid_n,varid_f)
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 34
+    return
   end if
 
-  call cdfCls(ncid)
+  ier = nf90_put_var(ncid,varid_x1,x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_x2,x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid_f,f)
+  if(ier.ne.NF90_NOERR) then
+    ier = 35
+    return
+  end if
+
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 36
 
   return
 end subroutine EZspline_2NetCDF_cloud2

--- a/ezspline/ezspline_cdfget3.f90
+++ b/ezspline/ezspline_cdfget3.f90
@@ -1,19 +1,23 @@
-#ifdef _EZCDF
-subroutine ezspline_cdfget3(ncid,zname,fspl,idim1,idim2,idim3,ifail)
+#ifdef _NETCDF
+subroutine ezspline_cdfget3(ncid,zname,fspl,i1,i2,i3,ier)
   use psp_precision_mod, only: fp
-  use EZcdf
+  use netcdf
   implicit NONE
 
   ! (due to ezspline rank limitation) read 4d object as 3d object
   ! use f77 interface style, should prevent unnecessary array copy.
 
-  integer, intent(in) :: ncid             ! opened NetCDF file
-  character(len=*),intent(in) :: zname       ! name to us for writing
-  integer, intent(in) :: idim1,idim2,idim3   ! spline data dimensions
-  real(fp), intent(out) :: fspl(idim1,idim2,idim3)  ! spline data & coefficients
-  integer, intent(out) :: ifail           ! status retruned from NetCDF
+  integer,                       intent(in)  :: ncid  ! opened NetCDF file
+  character(len=*),              intent(in)  :: zname ! name to us for writing
+  integer,                       intent(in)  :: i1    ! spline data dimensions
+  integer,                       intent(in)  :: i2    ! spline data dimensions
+  integer,                       intent(in)  :: i3    ! spline data dimensions
+  real(fp), dimension(i1,i2,i3), intent(out) :: fspl  ! spline data and coefficients
+  integer,                       intent(out) :: ier   ! status returned from NetCDF
+  integer :: varid
 
-  call cdfGetVar(ncid, trim(zname), fspl, ifail)
+  ier = nf90_inq_varid(ncid,trim(zname),varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,fspl)
 
   return
 end subroutine ezspline_cdfget3

--- a/ezspline/ezspline_cdfput3.f90
+++ b/ezspline/ezspline_cdfput3.f90
@@ -1,19 +1,23 @@
-#ifdef _EZCDF
-subroutine ezspline_cdfput3(ncid,zname,fspl,idim1,idim2,idim3,ifail)
+#ifdef _NETCDF
+subroutine ezspline_cdfput3(ncid,zname,fspl,i1,i2,i3,ier)
   use psp_precision_mod, only: fp
-  use EZcdf
+  use netcdf
   implicit NONE
 
   ! (due to ezspline rank limitation) write 4d object as 3d object
   ! use f77 interface style, should prevent unnecessary array copy.
 
-  integer, intent(in) :: ncid             ! opened NetCDF file
-  character(len=*),intent(in) :: zname       ! name to us for writing
-  integer, intent(in) :: idim1,idim2,idim3   ! spline data dimensions
-  real(fp), intent(in) :: fspl(idim1,idim2,idim3)  ! spline data & coefficients
-  integer, intent(out) :: ifail           ! status retruned from NetCDF
+  integer,                       intent(in)  :: ncid  ! opened NetCDF file
+  character(len=*),              intent(in)  :: zname ! name to us for writing
+  integer,                       intent(in)  :: i1    ! spline data dimensions
+  integer,                       intent(in)  :: i2    ! spline data dimensions
+  integer,                       intent(in)  :: i3    ! spline data dimensions
+  real(fp), dimension(i1,i2,i3), intent(in)  :: fspl  ! spline data and coefficients
+  integer,                       intent(out) :: ier   ! status returned from NetCDF
+  integer :: varid
 
-  call cdfPutVar(ncid, trim(zname), fspl, ifail)
+  ier = nf90_inq_varid(ncid,trim(zname),varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,fspl)
 
   return
 end subroutine ezspline_cdfput3

--- a/ezspline/ezspline_load.f90
+++ b/ezspline/ezspline_load.f90
@@ -1,8 +1,4 @@
-#ifdef _EZCDF
-
-!
-! 1-D
-!
+#ifdef _NETCDF
 
 !  DMC modifications -- spl_name optional argument.
 !  a single file can contain more than one spline (or not).  If it does
@@ -14,27 +10,26 @@
 !  for and read fullsv data if it is present; if not, the spline coefficients
 !  are recalculated.
 
+!
+! 1-D
+!
+
 subroutine EZspline_load1(spline_o, filename, ier, spl_name)
   use psp_precision_mod, only: fp
   use EZspline_obj
-  use EZcdf
+  use netcdf
   implicit none
-  type(EZspline1) :: spline_o
-  character(len=*) :: filename
-  ! ier:
-  ! 21=could not load spline object from file filename
-  ! 22=loaded spline object from file filename but failed at coefficient set-up
-  integer, intent(out) :: ier
-
-  character(len=*), intent(in), OPTIONAL :: spl_name  ! specify name of spline
-  !  to be read-- in case file contains more than one.
-
-  integer ncid, ifail
-  integer dimlens(3)
-  integer n1, BCS1(2)
+  type(EZspline1),            intent(out) :: spline_o
+  character(len=*),           intent(in)  :: filename
+  integer,                    intent(out) :: ier
+  character(len=*), optional, intent(in)  :: spl_name  ! specify name of spline to be read
+                                                       ! in case file contains more than one
+  integer :: ncid
+  integer :: dimid_n1, dimid_n2, dimid_xnpkg
+  integer :: n1
+  integer :: varid
+  integer, dimension(2) :: bcs1
   real(fp), dimension(:), allocatable :: f
-
-  character(len=4) :: data_type
 
   character(len=32) :: zpre
   logical :: fullsv
@@ -45,91 +40,103 @@ subroutine EZspline_load1(spline_o, filename, ier, spl_name)
     zpre = ' '
   end if
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'r') ! no error flag??
-  if(ncid==0) then
-    ier=43
+  ier = nf90_open(filename,NF90_NOWRITE,ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 20
     return
   end if
 
   ! check if n1 is present; check if spline object has correct rank
   !                         n2 should NOT be present.
 
-  call cdfInqVar(ncid, trim(zpre)//'n1', dimlens, data_type, ifail)
-  if(ifail.ne.0) then
-     ier = 21
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n1',dimid_n1)
+  if(ier.ne.NF90_NOERR) then
+    ier = 21
+    return
   end if
-  call cdfInqVar(ncid, trim(zpre)//'n2', dimlens, data_type, ifail)
-  if(ifail.eq.0) then
-     ier = 20
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n2',dimid_n2)
+  if(ier.eq.NF90_NOERR) then !n2 should NOT be present
+    ier = 22
+    return
   end if
 
   ! check if fullsv was in effect -- if so, x1pkg will be found.
 
-  fullsv=.FALSE.
-  call cdfInqVar(ncid, trim(zpre)//'x1pkg', dimlens, data_type, ifail)
-  if(ifail.eq.0) then
-     fullsv=.TRUE.
+  fullsv = .false.
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'xnpkg',dimid_xnpkg)
+  if(ier.eq.NF90_NOERR) then
+    fullsv = .true.
   end if
 
-  if( spline_o%nguard /= 123456789 ) call EZspline_preInit(spline_o)
+  if(spline_o%nguard.ne.123456789) call EZspline_preInit(spline_o)
 
-  if( ezspline_allocated(spline_o) ) call EZspline_free1(spline_o, ier)
+  if(ezspline_allocated(spline_o)) call EZspline_free1(spline_o,ier)
 
-  call cdfGetVar(ncid, trim(zpre)//'n1', n1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'isLinear', spline_o%isLinear, ifail)
-  if(ifail.ne.0) spline_o%isLinear=0
+  ier = nf90_inquire_dimension(ncid,dimid_n1,len=n1)
+  ier = nf90_inq_varid(ncid,trim(zpre)//'isLinear',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isLinear)
+  if(ier.ne.NF90_NOERR) spline_o%isLinear = 0
 
   if(spline_o%isLinear.eq.1) then
-     call EZlinear_init1(spline_o, n1, ier)
+    call EZlinear_init1(spline_o,n1,ier)
   else
-     BCS1 = (/0, 0/)
-     call EZspline_init1(spline_o, n1, BCS1, ier)
+    bcs1 = (/0, 0/)
+    call EZspline_init1(spline_o,n1,bcs1,ier)
   end if
   if(ier.ne.0) return
 
-  call cdfGetVar(ncid, trim(zpre)//'klookup1', spline_o%klookup1, ifail)
-  if(ifail.ne.0) spline_o%klookup1=-3  ! the old default
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%klookup1)
+  if(ier.ne.NF90_NOERR) spline_o%klookup1=-3  ! the old default
 
-  call cdfGetVar(ncid, trim(zpre)//'isHermite', spline_o%isHermite, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'isReady', spline_o%isReady, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'ibctype1', spline_o%ibctype1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'x1', spline_o%x1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval1min', spline_o%bcval1min, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval1max', spline_o%bcval1max, ifail)
-  if(ifail/=0) then
-     ier=44
-     return
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHermite',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isHermite)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isReady',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isReady)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ibctype1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval1min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval1max)
+  if(ier.ne.NF90_NOERR) then
+    ier = 23
+    return
   end if
 
   if(.not.fullsv) then
-     allocate(f(n1))
-     if(spline_o%isReady==1) then
-        call cdfGetVar(ncid, trim(zpre)//'f', f, ifail)
-     else
-        ier = 92
-     end if
+    allocate(f(n1))
+    if(spline_o%isReady==1) then
+      ier = nf90_inq_varid(ncid,trim(zpre)//'f',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,f)
+      if(ier.ne.NF90_NOERR) ier = 24
+    else
+      ier = 24
+    end if
   else
-     call cdfGetVar(ncid, trim(zpre)//'x1min', spline_o%x1min, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x1max', spline_o%x1max, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'ilin1', spline_o%ilin1, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x1pkg', spline_o%x1pkg, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'fspl', spline_o%fspl, ifail)
+    ier = nf90_inq_varid(ncid,trim(zpre)//'x1min',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1min)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1max',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1max)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin1',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ilin1)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1pkg',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1pkg)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'fspl',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%fspl)
+    if(ier.ne.NF90_NOERR) ier = 24
   end if
+  if(ier.ne.0) return
 
-  if(ifail /=0) then
-     ier = 21
-     return
-  end if
-
-  call cdfCls(ncid)
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 25
 
   if(.not.fullsv) then
-     call EZspline_setup1_x(spline_o, f, ier)
-     deallocate(f)
-     if(ifail /=0) ier = 22
+    call EZspline_setup1_x(spline_o, f, ier)
+    deallocate(f)
+    if(ier.ne.0) ier = 26
   end if
 
   return
@@ -137,322 +144,374 @@ end subroutine EZspline_load1
 
 
 
-
-
-!!
-!! 2-D
-!!
-
+!
+! 2-D
+!
 
 subroutine EZspline_load2(spline_o, filename, ier, spl_name)
   use psp_precision_mod, only: fp
   use EZspline_obj
-  use EZcdf
+  use netcdf
   implicit none
-  type(EZspline2) :: spline_o
-  character(len=*) :: filename
-  ! ier:
-  ! 20=attempt to load spline object with incorrect rank
-  ! 21=could not load spline object from file filename
-  ! 22=loaded spline object from file filename but failed at coefficient set-up
-  integer, intent(out) :: ier
+  type(EZspline2),            intent(out) :: spline_o
+  character(len=*),           intent(in)  :: filename
+  integer,                    intent(out) :: ier
+  character(len=*), optional, intent(in)  :: spl_name  ! specify name of spline to be read
+                                                       ! in case file contains more than one
 
-  character(len=*), intent(in), OPTIONAL :: spl_name  ! specify name of spline
-  !  to be read-- in case file contains more than one.
-
-  integer ncid, ifail, in0, in1, in2
-  integer dimlens(3)
-  integer n1, n2, BCS1(2), BCS2(2), hspline(2)
+  integer :: ncid
+  integer :: dimid_n1, dimid_n2, dimid_n3, dimid_xnpkg
+  integer :: dimid_in1, dimid_in2
+  integer :: n1, n2
+  integer :: in1, in2
+  integer :: varid
+  integer, dimension(2) :: bcs1, bcs2
+  integer, dimension(2) :: hspline
   real(fp), dimension(:,:), allocatable :: f
-
-  character(len=4) :: data_type
 
   character(len=32) zpre
   logical :: fullsv
 
   if(present(spl_name)) then
-     zpre = spl_name
+    zpre = spl_name
   else
-     zpre = ' '
+    zpre = ' '
   end if
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'r') ! no error flag??
-  if(ncid==0) then
-     ier=43
-     return
+  ier = nf90_open(filename,NF90_NOWRITE,ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 20
+    return
   end if
 
   ! check if n1 is present; check if spline object has correct rank
   !                         n2 should be present but not n3...
 
-  call cdfInqVar(ncid, trim(zpre)//'n1', dimlens, data_type, ifail)
-  if(ifail.ne.0) then
-     ier = 21
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n1',dimid_n1)
+  if(ier.ne.NF90_NOERR) then
+    ier = 21
+    return
   end if
-  call cdfInqVar(ncid, trim(zpre)//'n2', dimlens, data_type, ifail)
-  if(ifail.ne.0) then
-     ier = 20
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n2',dimid_n2)
+  if(ier.ne.NF90_NOERR) then
+    ier = 21
+    return
   end if
-  call cdfInqVar(ncid, trim(zpre)//'n3', dimlens, data_type, ifail)
-  if(ifail.eq.0) then
-     ier = 20
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n3',dimid_n3)
+  if(ier.eq.NF90_NOERR) then !n3 should NOT be present
+    ier = 22
+    return
   end if
 
   ! check if fullsv was in effect -- if so, x1pkg will be found.
 
-  fullsv=.FALSE.
-  call cdfInqVar(ncid, trim(zpre)//'x1pkg', dimlens, data_type, ifail)
-  if(ifail.eq.0) then
-     fullsv=.TRUE.
+  fullsv = .false.
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'xnpkg',dimid_xnpkg)
+  if(ier.eq.NF90_NOERR) then
+    fullsv = .true.
   end if
 
-  if(spline_o%nguard /= 123456789 ) call EZspline_preInit(spline_o)
+  if(spline_o%nguard /= 123456789) call EZspline_preInit(spline_o)
 
-  if( ezspline_allocated(spline_o) ) call EZspline_free2(spline_o, ier)
+  if(ezspline_allocated(spline_o)) call EZspline_free2(spline_o,ier)
 
-  call cdfGetVar(ncid, trim(zpre)//'n1', n1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'n2', n2, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'isLinear', spline_o%isLinear, ifail)
-  if(ifail.ne.0) spline_o%isLinear=0
-  call cdfGetVar(ncid, trim(zpre)//'isHybrid', spline_o%isHybrid, ifail)
-  if(ifail.ne.0) spline_o%isHybrid=0
+  ier = nf90_inquire_dimension(ncid,dimid_n1,len=n1)
+  ier = nf90_inquire_dimension(ncid,dimid_n2,len=n2)
+
+  ier = nf90_inq_varid(ncid,trim(zpre)//'isLinear',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isLinear)
+  if(ier.ne.NF90_NOERR) spline_o%isLinear = 0
+
+  ier = nf90_inq_varid(ncid,trim(zpre)//'isHybrid',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isHybrid)
+  if(ier.ne.NF90_NOERR) spline_o%isHybrid = 0
   spline_o%hspline = 0
 
   if(spline_o%isLinear.eq.1) then
-     call EZlinear_init2(spline_o, n1, n2, ier)
+    call EZlinear_init2(spline_o,n1,n2,ier)
   else if(spline_o%isHybrid.eq.1) then
-     call cdfGetVar(ncid, trim(zpre)//'hspline', hspline, ifail)
-     call EZhybrid_init2_x(spline_o, n1, n2, hspline, ier)
+    ier = nf90_inq_varid(ncid,trim(zpre)//'hspline',varid)
+    ier = nf90_get_var(ncid,varid,hspline)
+    call EZhybrid_init2_x(spline_o,n1,n2,hspline,ier)
   else
-     BCS1 = (/0, 0/); BCS2 = (/0, 0/)
-     call EZspline_init2(spline_o, n1, n2, BCS1, BCS2, ier)
+    bcs1 = (/0, 0/); bcs2 = (/0, 0/)
+    call EZspline_init2(spline_o,n1,n2,bcs1,bcs2,ier)
   end if
   if(ier.ne.0) return
 
-  call cdfGetVar(ncid, trim(zpre)//'klookup1', spline_o%klookup1, ifail)
-  if(ifail.ne.0) spline_o%klookup1=-3  ! the old default
-  call cdfGetVar(ncid, trim(zpre)//'klookup2', spline_o%klookup2, ifail)
-  if(ifail.ne.0) spline_o%klookup2=-3  ! the old default
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%klookup1)
+  if(ier.ne.NF90_NOERR) spline_o%klookup1=-3  ! the old default
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%klookup2)
+  if(ier.ne.NF90_NOERR) spline_o%klookup2=-3  ! the old default
 
-  call cdfGetVar(ncid, trim(zpre)//'isHermite', spline_o%isHermite, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'isReady', spline_o%isReady, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'ibctype1', spline_o%ibctype1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'ibctype2', spline_o%ibctype2, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'x1', spline_o%x1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'x2', spline_o%x2, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval1min', spline_o%bcval1min, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval1max', spline_o%bcval1max, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval2min', spline_o%bcval2min, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval2max', spline_o%bcval2max, ifail)
-  if(ifail/=0) then
-     ier=44
-     return
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHermite',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isHermite)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isReady',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isReady)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ibctype1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ibctype2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval1min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval1max)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval2min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval2max)
+  if(ier.ne.NF90_NOERR) then
+    ier = 23
+    return
   end if
 
-  in0=size(spline_o%fspl,1)
-  in1=size(spline_o%fspl,2)
-  in2=size(spline_o%fspl,3)
-
   if(.not.fullsv) then
-     allocate(f(in1,in2))
-     if(spline_o%isReady==1) then
-        call cdfGetVar(ncid, trim(zpre)//'f', f, ifail)
-     else
-        ier = 92
-     end if
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in1',dimid_in1)
+    ier = nf90_inquire_dimension(ncid,dimid_in1,len=in1)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in2',dimid_in2)
+    ier = nf90_inquire_dimension(ncid,dimid_in2,len=in2)
+    allocate(f(in1,in2))
+    if(spline_o%isReady==1) then
+      ier = nf90_inq_varid(ncid,trim(zpre)//'f',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,f)
+      if(ier.ne.NF90_NOERR) ier = 24
+    else
+      ier = 24
+    end if
   else
-     call cdfGetVar(ncid, trim(zpre)//'x1min', spline_o%x1min, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x1max', spline_o%x1max, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'ilin1', spline_o%ilin1, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x2min', spline_o%x2min, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x2max', spline_o%x2max, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'ilin2', spline_o%ilin2, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x1pkg', spline_o%x1pkg, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x2pkg', spline_o%x2pkg, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'fspl', spline_o%fspl, ifail)
+    ier = nf90_inq_varid(ncid,trim(zpre)//'x1min',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1min)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1max',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1max)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin1',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ilin1)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2min',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2min)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2max',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2max)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin2',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ilin2)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1pkg',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1pkg)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2pkg',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2pkg)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'fspl',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%fspl)
+    if(ier.ne.NF90_NOERR) ier = 24
   end if
+  if(ier.ne.0) return
 
-  if(ifail /=0) then
-     ier = 21
-     return
-  end if
-
-  call cdfCls(ncid)
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 25
 
   if(.not.fullsv) then
-     call EZspline_setup2_x(spline_o, f, ier)
-     deallocate(f)
-     if(ifail /=0) ier = 22
+    call EZspline_setup2_x(spline_o, f, ier)
+    deallocate(f)
+    if(ier.ne.0) ier = 26
   end if
 
   return
 end subroutine EZspline_load2
 
 
-!!!
-!!! 3-D
-!!!
-
+!
+! 3-D
+!
 
 subroutine EZspline_load3(spline_o, filename, ier, spl_name)
   use psp_precision_mod, only: fp
   use EZspline_obj
-  use EZcdf
+  use netcdf
   implicit none
-  type(EZspline3) :: spline_o
-  character(len=*) :: filename
-  ! ier:
-  ! 21=could not load spline object from file filename
-  ! 22=loaded spline object from file filename but failed at coefficient set-up
-  integer, intent(out) :: ier
+  type(EZspline3),            intent(out) :: spline_o
+  character(len=*),           intent(in)  :: filename
+  integer,                    intent(out) :: ier
+  character(len=*), optional, intent(in)  :: spl_name  ! specify name of spline to be read
+                                                       ! in case file contains more than one
 
-  character(len=*), intent(in), OPTIONAL :: spl_name  ! specify name of spline
-  !  to be read-- in case file contains more than one.
-
-  integer ncid, ifail, in0, in1, in2, in3
-  integer dimlens(3)
-  integer n1, n2, n3, BCS1(2), BCS2(2), BCS3(2), hspline(3)
+  integer :: ncid
+  integer :: dimid_n1, dimid_n2, dimid_n3, dimid_xnpkg
+  integer :: dimid_in1, dimid_in2, dimid_in3
+  integer :: n1, n2, n3
+  integer :: in1, in2, in3
+  integer :: varid
+  integer, dimension(2) :: bcs1, bcs2, bcs3
+  integer, dimension(3) :: hspline
   real(fp), dimension(:,:,:), allocatable :: f
-
-  character(len=4) :: data_type
 
   character(len=32) :: zpre
   logical :: fullsv
 
   if(present(spl_name)) then
-     zpre = spl_name
+    zpre = spl_name
   else
-     zpre = ' '
+    zpre = ' '
   end if
 
-  ier = 0
-  call cdfOpn(ncid, filename, 'r') ! no error flag??
-  if(ncid==0) then
-     ier=43
-     return
+  ier = nf90_open(filename,NF90_NOWRITE,ncid)
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 20
+    return
   end if
 
   ! check if n1 is present; check if spline object has correct rank
   !                         n2 and n3 should also be present.
 
-  call cdfInqVar(ncid, trim(zpre)//'n1', dimlens, data_type, ifail)
-  if(ifail.ne.0) then
-     ier = 21
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n1',dimid_n1)
+  if(ier.ne.NF90_NOERR) then
+    ier = 21
+    return
   end if
-  call cdfInqVar(ncid, trim(zpre)//'n2', dimlens, data_type, ifail)
-  if(ifail.ne.0) then
-     ier = 20
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n2',dimid_n2)
+  if(ier.ne.NF90_NOERR) then
+    ier = 21
+    return
   end if
-  call cdfInqVar(ncid, trim(zpre)//'n3', dimlens, data_type, ifail)
-  if(ifail.ne.0) then
-     ier = 20
-     return
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'n3',dimid_n3)
+  if(ier.ne.NF90_NOERR) then
+    ier = 21
+    return
   end if
 
   ! check if fullsv was in effect -- if so, x1pkg will be found.
 
-  fullsv=.FALSE.
-  call cdfInqVar(ncid, trim(zpre)//'x1pkg', dimlens, data_type, ifail)
-  if(ifail.eq.0) then
-     fullsv=.TRUE.
+  fullsv = .false.
+  ier = nf90_inq_dimid(ncid,trim(zpre)//'xnpkg',dimid_xnpkg)
+  if(ier.eq.NF90_NOERR) then
+    fullsv = .true.
   end if
 
-  if(spline_o%nguard /= 123456789 ) call EZspline_preInit(spline_o)
+  if(spline_o%nguard /= 123456789) call EZspline_preInit(spline_o)
 
-  if( ezspline_allocated(spline_o) ) call EZspline_free3(spline_o, ier)
+  if(ezspline_allocated(spline_o)) call EZspline_free3(spline_o, ier)
 
-  call cdfGetVar(ncid, trim(zpre)//'n1', n1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'n2', n2, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'n3', n3, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'isLinear', spline_o%isLinear, ifail)
-  if(ifail.ne.0) spline_o%isLinear=0
-  call cdfGetVar(ncid, trim(zpre)//'isHybrid', spline_o%isHybrid, ifail)
-  if(ifail.ne.0) spline_o%isHybrid=0
+  ier = nf90_inquire_dimension(ncid,dimid_n1,len=n1)
+  ier = nf90_inquire_dimension(ncid,dimid_n2,len=n2)
+  ier = nf90_inquire_dimension(ncid,dimid_n3,len=n3)
+
+  ier = nf90_inq_varid(ncid,trim(zpre)//'isLinear',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isLinear)
+  if(ier.ne.NF90_NOERR) spline_o%isLinear = 0
+
+  ier = nf90_inq_varid(ncid,trim(zpre)//'isHybrid',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isHybrid)
+  if(ier.ne.NF90_NOERR) spline_o%isHybrid = 0
   spline_o%hspline = 0
 
   if(spline_o%isLinear.eq.1) then
-     call EZlinear_init3(spline_o, n1, n2, n3, ier)
+    call EZlinear_init3(spline_o,n1,n2,n3,ier)
   else if(spline_o%isHybrid.eq.1) then
-     call cdfGetVar(ncid, trim(zpre)//'hspline', hspline, ifail)
-     call EZhybrid_init3_x(spline_o, n1, n2, n3, hspline, ier)
+    ier = nf90_inq_varid(ncid,trim(zpre)//'hspline',varid)
+    ier = nf90_get_var(ncid,varid,hspline)
+    call EZhybrid_init3_x(spline_o,n1,n2,n3,hspline,ier)
   else
-     BCS1 = (/0, 0/); BCS2 = (/0, 0/); BCS3 = (/0, 0/)
-     call EZspline_init3(spline_o, n1, n2, n3, BCS1, BCS2, BCS3, ier)
+    bcs1 = (/0, 0/); bcs2 = (/0, 0/); bcs3 = (/0, 0/)
+    call EZspline_init3(spline_o,n1,n2,n3,bcs1,bcs2,bcs3,ier)
   end if
   if(ier.ne.0) return
 
-  call cdfGetVar(ncid, trim(zpre)//'klookup1', spline_o%klookup1, ifail)
-  if(ifail.ne.0) spline_o%klookup1=-3  ! the old default
-  call cdfGetVar(ncid, trim(zpre)//'klookup2', spline_o%klookup2, ifail)
-  if(ifail.ne.0) spline_o%klookup2=-3  ! the old default
-  call cdfGetVar(ncid, trim(zpre)//'klookup3', spline_o%klookup3, ifail)
-  if(ifail.ne.0) spline_o%klookup3=-3  ! the old default
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%klookup1)
+  if(ier.ne.NF90_NOERR) spline_o%klookup1=-3  ! the old default
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%klookup2)
+  if(ier.ne.NF90_NOERR) spline_o%klookup2=-3  ! the old default
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup3',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%klookup3)
+  if(ier.ne.NF90_NOERR) spline_o%klookup3=-3  ! the old default
 
-  call cdfGetVar(ncid, trim(zpre)//'isHermite', spline_o%isHermite, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'isReady', spline_o%isReady, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'ibctype1', spline_o%ibctype1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'ibctype2', spline_o%ibctype2, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'ibctype3', spline_o%ibctype3, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'x1', spline_o%x1, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'x2', spline_o%x2, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'x3', spline_o%x3, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval1min', spline_o%bcval1min, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval1max', spline_o%bcval1max, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval2min', spline_o%bcval2min, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval2max', spline_o%bcval2max, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval3min', spline_o%bcval3min, ifail)
-  call cdfGetVar(ncid, trim(zpre)//'bcval3max', spline_o%bcval3max, ifail)
-  if(ifail/=0) then
-     ier=44
-     return
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHermite',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isHermite)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isReady',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%isReady)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ibctype1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ibctype2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype3',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ibctype3)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x3)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval1min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval1max)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval2min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval2max)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval3min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval3min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval3max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%bcval3max)
+  if(ier.ne.NF90_NOERR) then
+    ier = 23
+    return
   end if
 
-  in0=size(spline_o%fspl,1)
-  in1=size(spline_o%fspl,2)
-  in2=size(spline_o%fspl,3)
-  in3=size(spline_o%fspl,4)
-
   if(.not.fullsv) then
-     allocate(f(in1,in2,in3))
-     if(spline_o%isReady==1) then
-        call cdfGetVar(ncid, trim(zpre)//'f', f, ifail)
-     else
-        ier = 92
-     end if
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in1',dimid_in1)
+    ier = nf90_inquire_dimension(ncid,dimid_in1,len=in1)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in2',dimid_in2)
+    ier = nf90_inquire_dimension(ncid,dimid_in2,len=in2)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in2',dimid_in3)
+    ier = nf90_inquire_dimension(ncid,dimid_in2,len=in3)
+    allocate(f(in1,in2,in3))
+    if(spline_o%isReady==1) then
+      ier = nf90_inq_varid(ncid,trim(zpre)//'f',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,f)
+      if(ier.ne.NF90_NOERR) ier = 24
+    else
+      ier = 24
+    end if
   else
-     call cdfGetVar(ncid, trim(zpre)//'x1min', spline_o%x1min, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x1max', spline_o%x1max, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'ilin1', spline_o%ilin1, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x2min', spline_o%x2min, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x2max', spline_o%x2max, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'ilin2', spline_o%ilin2, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x3min', spline_o%x3min, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x3max', spline_o%x3max, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'ilin3', spline_o%ilin3, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x1pkg', spline_o%x1pkg, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x2pkg', spline_o%x2pkg, ifail)
-     call cdfGetVar(ncid, trim(zpre)//'x3pkg', spline_o%x3pkg, ifail)
-     call ezspline_cdfget3(ncid, trim(zpre)//'fspl', spline_o%fspl, &
-          in0*in1, in2, in3, ifail)
+    ier = nf90_inq_varid(ncid,trim(zpre)//'x1min',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1min)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1max',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1max)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin1',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ilin1)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2min',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2min)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2max',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2max)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin2',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ilin2)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3min',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x3min)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3max',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x3max)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin3',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%ilin3)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1pkg',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x1pkg)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2pkg',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x2pkg)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3pkg',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%x3pkg)
+    if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'fspl',varid)
+    if(ier.eq.NF90_NOERR) ier = nf90_get_var(ncid,varid,spline_o%fspl)
+    if(ier.ne.NF90_NOERR) ier = 24
   end if
+  if(ier.ne.0) return
 
-  if(ifail /=0) then
-     ier = 21
-     return
-  end if
-
-  call cdfCls(ncid)
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 25
 
   if(.not.fullsv) then
-     call EZspline_setup3_x(spline_o, f, ier)
-     deallocate(f)
-     if(ifail /=0) ier = 22
+    call EZspline_setup3_x(spline_o, f, ier)
+    deallocate(f)
+    if(ier.ne.0) ier = 26
   end if
 
   return

--- a/ezspline/ezspline_mod.f90
+++ b/ezspline/ezspline_mod.f90
@@ -1175,7 +1175,7 @@ module EZspline
 
   end interface
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   interface EZspline_save
     !
     ! Save spline/Akima Hermite/Linear object in netcdf file 'filename'. Use
@@ -1197,7 +1197,7 @@ module EZspline
     !
     subroutine EZspline_save3(spline_o,filename,ier,spl_name,fullsave)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       type(EZspline3) :: spline_o
       character(len=*) :: filename
       integer, intent(out) :: ier
@@ -1208,7 +1208,7 @@ module EZspline
 
     subroutine EZspline_save2(spline_o,filename,ier,spl_name,fullsave)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       type(EZspline2) :: spline_o
       character(len=*) :: filename
       integer, intent(out) :: ier
@@ -1219,7 +1219,7 @@ module EZspline
 
     subroutine EZspline_save1(spline_o,filename,ier,spl_name,fullsave)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       type(EZspline1), intent(in) :: spline_o
       character(len=*), intent(in) :: filename
       integer, intent(out) :: ier
@@ -1231,7 +1231,7 @@ module EZspline
   end interface
 #endif
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   interface EZspline_load
     !
     ! Load spline/Akima Hermite object from netcdf file 'filename'. Use
@@ -1248,7 +1248,7 @@ module EZspline
 
     subroutine EZspline_load3(spline_o, filename, ier, spl_name)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       type(EZspline3) :: spline_o
       character(len=*) :: filename
       integer, intent(out) :: ier
@@ -1257,7 +1257,7 @@ module EZspline
 
     subroutine EZspline_load2(spline_o, filename, ier, spl_name)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       type(EZspline2) :: spline_o
       character(len=*) :: filename
       integer, intent(out) :: ier
@@ -1266,7 +1266,7 @@ module EZspline
 
     subroutine EZspline_load1(spline_o, filename, ier, spl_name)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       type(EZspline1) :: spline_o
       character(len=*) :: filename
       integer, intent(out) :: ier
@@ -1352,7 +1352,7 @@ module EZspline
   ! EZspline object-less methods (first argument is NOT an EZspline1,2,3 type).
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   interface EZspline_2NetCDF
     !
     ! Save data in netCDF file 'filename'. To save an EZspline1,2,3 object use
@@ -1360,7 +1360,7 @@ module EZspline
     !
     subroutine EZspline_2NetCDF_array3(n1, n2, n3, x1, x2, x3, f, filename, ier)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       implicit none
       integer, intent(in) :: n1, n2, n3
       real(fp), intent(in) :: x1(:), x2(:), x3(:), f(:, :, :)
@@ -1370,7 +1370,7 @@ module EZspline
 
     subroutine EZspline_2NetCDF_array2(n1, n2, x1, x2, f, filename, ier)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       implicit none
       integer, intent(in) :: n1, n2
       real(fp), intent(in) ::  x1(:), x2(:), f(:,:)
@@ -1378,19 +1378,19 @@ module EZspline
       integer, intent(out) :: ier
     end subroutine EZspline_2NetCDF_array2
 
-    subroutine EZspline_2NetCDF1(n1, x1, f, filename, ier)
+    subroutine EZspline_2NetCDF_array1(n1, x1, f, filename, ier)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       implicit none
       integer, intent(in) :: n1
       real(fp), intent(in) :: x1(:), f(:)
       character(len=*), intent(in) :: filename
       integer, intent(out) :: ier
-    end subroutine EZspline_2NetCDF1
+    end subroutine EZspline_2NetCDF_array1
 
     subroutine EZspline_2NetCDF_cloud3(n, x1, x2, x3, f, filename, ier)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       implicit none
       integer, intent(in) :: n
       real(fp), intent(in) :: x1(:), x2(:), x3(:), f(:)
@@ -1400,7 +1400,7 @@ module EZspline
 
     subroutine EZspline_2NetCDF_cloud2(n, x1, x2, f, filename, ier)
       use EZspline_obj
-      use EZcdf
+      use netcdf
       implicit none
       integer, intent(in) :: n
       real(fp), intent(in) :: x1(:), x2(:), f(:)

--- a/ezspline/ezspline_save.f90
+++ b/ezspline/ezspline_save.f90
@@ -1,4 +1,4 @@
-#ifdef _EZCDF
+#ifdef _NETCDF
 
 !
 !  MOD DMC Apr 2007 -- support Hybrid spline objects.
@@ -7,45 +7,45 @@
 !   depending on how many dimensions are using cubic interpolation.  So,
 !   local variables in0, in1, in2, in3 are defined to distinguish these
 !   dimensions from the grid dimensions spline_o%n1, etc.
+
 !
 ! 1-D
 !
 
 subroutine EZspline_save1(spline_o, filename, ier, spl_name, fullsave)
+  use psp_precision_mod, only: fp
   use EZspline_obj
-  use EZcdf
+  use netcdf
   implicit none
-  type(EZspline1),  intent(in) :: spline_o
-  character(len=*), intent(in) :: filename
-  ! ier:
-  ! 17=could not save spline object in file filename
-  integer, intent(out) :: ier
-
+  type(EZspline1),  intent(in)  :: spline_o
+  character(len=*), intent(in)  :: filename
+  integer,          intent(out) :: ier
   !  if SPL_NAME is set, APPEND to file instead of creating new; prepend
   !  name to all NetCDF data items.  This allows one file to contain
-  !  multiple items. (new dmc Mar 2006)
-  character(len=*), intent(in), optional :: spl_name  ! optional spline "name"
-
+  !  multiple items.
+  character(len=*), intent(in), optional :: spl_name
   !  if FULLSAVE is set .TRUE., save derived coefficients along with data
-  !  this saves recalculating the coefficients when file is read (Mar 2006)
+  !  this saves recalculating the coefficients when file is read
   logical, intent(in), optional :: fullsave
 
-  integer ncid, ifail, in0, in1
-  integer dimlens(3)
-  character(len=2), parameter :: real8='R8'
-  character(len=3), parameter :: int='INT'
+  integer :: ncid, in0, in1, ix2
+  integer :: varid
+  integer :: ndims
+  integer :: dimid_n1, dimid_n2, dimid_n3
+  integer :: dimid_nbcs
+  integer :: dimid_x2
+  integer :: dimid_in0, dimid_in1
+  integer, dimension(3) :: dimids
 
   character(len=32) :: zpre
-  logical :: fullsv,imodify
+  logical :: fullsv, imodify
 
   ier = 0
-  if(spline_o%isReady /= 1) then
-    ier = 94
+  if(spline_o%isReady.ne.1) then
+    ier = 91
     return
   end if
 
-  in0 = size(spline_o%fspl,1)
-  in1 = size(spline_o%fspl,2)
   if(present(spl_name)) then
     call ezspline_spl_name_chk(spl_name,ier)
     if(ier.ne.0) return
@@ -60,80 +60,139 @@ subroutine EZspline_save1(spline_o, filename, ier, spl_name, fullsave)
     fullsv=.FALSE.
   end if
 
+  if(fullsv) then
+    in0 = size(spline_o%fspl,1)
+    in1 = size(spline_o%fspl,2)
+    ix2 = size(spline_o%x1pkg,2)
+  end if
+
   if(zpre.eq.' ') then
-    call cdfOpn(ncid, filename, 'w') ! no error flag??
+    ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
     imodify=.FALSE.
   else
-    call cdfOpn(ncid, filename, 'v') ! Append if exists, else create new
+    ier = nf90_open(filename,NF90_WRITE,ncid)
+    if(ier.eq.NF90_NOERR) then
+      ier = nf90_redef(ncid)  ! start in "define mode".
+    else
+      ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+    endif
     imodify=.TRUE.
   end if
-  if(ncid==0) then
-    ier = 39
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 92
     return
   end if
 
-  dimlens = (/1, 1, 1/) ! scalar
-  call ezspline_defVar(ncid, trim(zpre)//'n1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'klookup1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isHermite', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isLinear', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isReady', dimlens, int, imodify, ier)
-  dimlens = (/2, 1, 1/) 
-  call ezspline_defVar(ncid, trim(zpre)//'ibctype1', dimlens, int, imodify, ier)
-  dimlens = (/spline_o%n1, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'x1', dimlens, real8, imodify, ier)
-  dimlens = (/1, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval1min', dimlens, real8, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval1max', dimlens, real8, imodify, ier)
+  ier = NF90_NOERR
+  if(imodify) then
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'n1',dimid_n1)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'nbcs',dimid_nbcs)
+    if(fullsv) then
+      ier = nf90_inq_dimid(ncid,trim(zpre)//'xnpkg',dimid_x2)
+      ier = nf90_inq_dimid(ncid,trim(zpre)//'in0',dimid_in0)
+      ier = nf90_inq_dimid(ncid,trim(zpre)//'in1',dimid_in1)
+    end if
+  end if
+  if(ier.ne.NF90_NOERR .or. .not.imodify) then
+    ier = nf90_def_dim(ncid,trim(zpre)//'n1',spline_o%n1,dimid_n1)
+    ier = nf90_def_dim(ncid,trim(zpre)//'nbcs',2,dimid_nbcs)
+    if(fullsv) then
+      ier = nf90_def_dim(ncid,trim(zpre)//'xnpkg',ix2,dimid_x2)
+      ier = nf90_def_dim(ncid,trim(zpre)//'in0',in0,dimid_in0)
+      ier = nf90_def_dim(ncid,trim(zpre)//'in1',in1,dimid_in1)
+    end if
+  end if
+  if(ier.ne.NF90_NOERR) then
+    ier = 93
+    return
+  end if
+
+  ndims = 0
+  dimids = (/0, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'klookup1',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isHermite',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isLinear',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isReady',ndims,dimids,NF90_INT,imodify,varid,ier)
+  ndims = 1
+  dimids = (/dimid_nbcs, 0, 0/)
+  call ezspline_defVar(ncid, trim(zpre)//'ibctype1',ndims,dimids,NF90_INT,imodify,varid,ier)
+  dimids = (/dimid_n1, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'x1',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  ndims = 0
+  dimids = (/0, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval1min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval1max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   !
   ! save only the function values at the nodes
   !
-  dimlens = (/spline_o%n1, 1, 1/)
   if(.not.fullsv) then
-    call ezspline_defVar(ncid, trim(zpre)//'f', dimlens, real8, imodify, ier)
+    ndims = 1
+    dimids = (/dimid_n1, 0, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'f',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   else
-    dimlens = (/1, 1, 1/) ! scalar
-    call ezspline_defVar(ncid, trim(zpre)//'x1min', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x1max', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'ilin1', dimlens, int, imodify, ier)
-    dimlens = (/spline_o%n1, 4, 1/)
-    call ezspline_defVar(ncid, trim(zpre)//'x1pkg', dimlens, real8, imodify, ier)
-    dimlens = (/2, spline_o%n1, 1/)
-    call ezspline_defVar(ncid, trim(zpre)//'fspl', dimlens, real8, imodify, ier)
+    ndims = 0
+    dimids = (/0, 0, 0/) ! scalar
+    call ezspline_defVar(ncid,trim(zpre)//'x1min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x1max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'ilin1',ndims,dimids,NF90_INT,imodify,varid,ier)
+    ndims = 2
+    dimids = (/dimid_n1, dimid_x2, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'x1pkg',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    ndims = 2
+    dimids = (/dimid_in0, dimid_in1, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'fspl',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   end if
-  if(ier.ne.0) return
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 94
+    return
+  end if
 
-  call cdfPutVar(ncid, trim(zpre)//'n1', spline_o%n1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'klookup1', spline_o%klookup1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isHermite', spline_o%isHermite, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isLinear', spline_o%isLinear, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isReady', spline_o%isReady, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'ibctype1', spline_o%ibctype1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'x1', spline_o%x1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval1min', spline_o%bcval1min, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval1max', spline_o%bcval1max, ifail)
-  if(ifail/=0) then
-    ier=40
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%klookup1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHermite',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isHermite)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isLinear',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isLinear)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isReady',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isReady)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ibctype1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval1min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval1max)
+  if(ier.ne.NF90_NOERR) then
+    ier = 95
     return
   end if
 
   if(spline_o%isReady == 1) then
     if(.not.fullsv) then
-      call cdfPutVar(ncid, trim(zpre)//'f', spline_o%fspl(1,:), ifail)
+      ier = nf90_inq_varid(ncid,trim(zpre)//'f',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%fspl(1,:))
     else
-      call cdfPutVar(ncid, trim(zpre)//'x1min', spline_o%x1min, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x1max', spline_o%x1max, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'ilin1', spline_o%ilin1, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x1pkg', spline_o%x1pkg, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'fspl', spline_o%fspl, ifail)
+      ier = nf90_inq_varid(ncid,trim(zpre)//'x1min',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1min)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1max',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1max)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin1',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ilin1)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1pkg',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1pkg)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'fspl',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%fspl)
     end if
+    if(ier.ne.NF90_NOERR) ier = 96
   else
-    ier = 93
+    ier = 96
   end if
+  if(ier.ne.0) return
 
-  call cdfCls(ncid)
-
-  if(ifail /=0) ier = 17
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 97
 
   return
 end subroutine EZspline_save1
@@ -144,41 +203,39 @@ end subroutine EZspline_save1
 !!
 
 subroutine EZspline_save2(spline_o, filename, ier, spl_name, fullsave)
+  use psp_precision_mod, only: fp
   use EZspline_obj
-  use EZcdf
+  use netcdf
   implicit none
-  type(EZspline2) :: spline_o
-  character(len=*) :: filename
-  ! ier:
-  ! 17=could not save spline object in file filename
-  integer, intent(out) :: ier
-
+  type(EZspline2),  intent(in)  :: spline_o
+  character(len=*), intent(in)  :: filename
+  integer,          intent(out) :: ier
   !  if SPL_NAME is set, APPEND to file instead of creating new; prepend
   !  name to all NetCDF data items.  This allows one file to contain
-  !  multiple items. (new dmc Mar 2006)
+  !  multiple items.
   character(len=*), intent(in), optional :: spl_name  ! optional spline "name"
-
   !  if FULLSAVE is set .TRUE., save derived coefficients along with data
   !  this saves recalculating the coefficients when file is read (Mar 2006)
   logical, intent(in), optional :: fullsave
 
-  integer ncid, ifail, in0, in1, in2
-  integer dimlens(3)
-  character(len=2), parameter :: real8='R8'
-  character(len=3), parameter :: int='INT'
+  integer :: ncid, in0, in1, in2, ix2
+  integer :: varid
+  integer :: ndims
+  integer :: dimid_n1, dimid_n2, dimid_n3
+  integer :: dimid_nbcs
+  integer :: dimid_x2
+  integer :: dimid_in0, dimid_in1, dimid_in2
+  integer :: dimid_hs
+  integer, dimension(3) :: dimids
 
   character(len=32) :: zpre
-  logical :: fullsv,imodify
+  logical :: fullsv, imodify
 
   ier = 0
-  if(spline_o%isReady /= 1) then
-    ier = 94
+  if(spline_o%isReady.ne.1) then
+    ier = 91
     return
   end if
-
-  in0 = size(spline_o%fspl,1)
-  in1 = size(spline_o%fspl,2)
-  in2 = size(spline_o%fspl,3)
 
   if(present(spl_name)) then
     call ezspline_spl_name_chk(spl_name,ier)
@@ -194,108 +251,183 @@ subroutine EZspline_save2(spline_o, filename, ier, spl_name, fullsave)
     fullsv=.FALSE.
   end if
 
+  in0 = size(spline_o%fspl,1)
+  in1 = size(spline_o%fspl,2)
+  in2 = size(spline_o%fspl,3)
+
+  if(fullsv) then
+    ix2 = size(spline_o%x1pkg,2)
+  end if
+
   if(zpre.eq.' ') then
-    call cdfOpn(ncid, filename, 'w') ! no error flag??
+    ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
     imodify=.FALSE.
   else
-    call cdfOpn(ncid, filename, 'v') ! Append if exists, else create new
+    ier = nf90_open(filename,NF90_WRITE,ncid)
+    if(ier.eq.NF90_NOERR) then
+      ier = nf90_redef(ncid)  ! start in "define mode".
+    else
+      ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+    endif
     imodify=.TRUE.
   end if
-  if(ncid==0) then
-    ier = 39
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 92
     return
   end if
 
-  dimlens = (/1, 1, 1/) ! scalar
-  call ezspline_defVar(ncid, trim(zpre)//'n1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'n2', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'klookup1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'klookup2', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isHermite', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isLinear', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isHybrid', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isReady', dimlens, int, imodify, ier)
-  dimlens = (/2, 1, 1/) 
-  call ezspline_defvar(ncid, trim(zpre)//'hspline', dimlens, int, imodify, ier)
-  dimlens = (/2, 1, 1/) 
-  call ezspline_defVar(ncid, trim(zpre)//'ibctype1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'ibctype2', dimlens, int, imodify, ier)
-  dimlens = (/spline_o%n1, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'x1', dimlens, real8, imodify, ier)
-  dimlens = (/spline_o%n2, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'x2', dimlens, real8, imodify, ier)
-  dimlens = (/in2, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval1min', dimlens, real8, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval1max', dimlens, real8, imodify, ier)
-  dimlens = (/in1, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval2min', dimlens, real8, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval2max', dimlens, real8, imodify, ier)
+  ier = NF90_NOERR
+  if(imodify) then
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'n1',dimid_n1)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'n2',dimid_n2)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'nbcs',dimid_nbcs)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in0',dimid_in0)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in1',dimid_in1)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in2',dimid_in2)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'hs',dimid_hs)
+    if(fullsv) then
+      ier = nf90_inq_dimid(ncid,trim(zpre)//'xnpkg',dimid_x2)
+    end if
+  end if
+  if(ier.ne.NF90_NOERR .or. .not.imodify) then
+    ier = nf90_def_dim(ncid,trim(zpre)//'n1',spline_o%n1,dimid_n1)
+    ier = nf90_def_dim(ncid,trim(zpre)//'n2',spline_o%n2,dimid_n2)
+    ier = nf90_def_dim(ncid,trim(zpre)//'nbcs',2,dimid_nbcs)
+    ier = nf90_def_dim(ncid,trim(zpre)//'in0',in0,dimid_in0)
+    ier = nf90_def_dim(ncid,trim(zpre)//'in1',in1,dimid_in1)
+    ier = nf90_def_dim(ncid,trim(zpre)//'in2',in2,dimid_in2)
+    ier = nf90_def_dim(ncid,trim(zpre)//'hs',2,dimid_hs)
+    if(fullsv) then
+      ier = nf90_def_dim(ncid,trim(zpre)//'xnpkg',ix2,dimid_x2)
+    end if
+  end if
+  if(ier.ne.NF90_NOERR) then
+    ier = 93
+    return
+  end if
+
+  ndims = 0
+  dimids = (/0, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'klookup1',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'klookup2',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isHermite',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isLinear',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isHybrid',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isReady',ndims,dimids,NF90_INT,imodify,varid,ier)
+  ndims = 1
+  dimids = (/dimid_hs, 0, 0/)
+  call ezspline_defvar(ncid,trim(zpre)//'hspline',ndims,dimids,NF90_INT,imodify,varid,ier)
+  dimids = (/dimid_nbcs, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'ibctype1',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'ibctype2',ndims,dimids,NF90_INT,imodify,varid,ier)
+  dimids = (/dimid_n1, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'x1',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  dimids = (/dimid_n2, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'x2',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  dimids = (/dimid_in2, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval1min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval1max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  dimids = (/dimid_in1, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval2min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval2max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   !
   ! save only the function values at the nodes
   !
-  dimlens = (/in1, in2, 1/)
   if(.not.fullsv) then
-    call ezspline_defVar(ncid, trim(zpre)//'f', dimlens, real8, imodify, ier)
+    ndims = 2
+    dimids = (/dimid_in1, dimid_in2, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'f',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   else
-    dimlens = (/1, 1, 1/) ! scalar
-    call ezspline_defVar(ncid, trim(zpre)//'x1min', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x1max', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'ilin1', dimlens, int, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x2min', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x2max', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'ilin2', dimlens, int, imodify, ier)
-    dimlens = (/spline_o%n1, 4, 1/)
-    call ezspline_defVar(ncid, trim(zpre)//'x1pkg', dimlens, real8, imodify, ier)
-    dimlens = (/spline_o%n2, 4, 1/)
-    call ezspline_defVar(ncid, trim(zpre)//'x2pkg', dimlens, real8, imodify, ier)
-    dimlens = (/in0, in1, in2/)
-    call ezspline_defVar(ncid, trim(zpre)//'fspl', dimlens, real8, imodify, ier)
+    ndims = 0
+    dimids = (/0, 0, 0/) ! scalar
+    call ezspline_defVar(ncid,trim(zpre)//'x1min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x1max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'ilin1',ndims,dimids,NF90_INT,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x2min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x2max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'ilin2',ndims,dimids,NF90_INT,imodify,varid,ier)
+    ndims = 2
+    dimids = (/dimid_n1, dimid_x2, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'x1pkg',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    dimids = (/dimid_n2, dimid_x2, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'x2pkg',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    ndims = 3
+    dimids = (/dimid_in0, dimid_in1, dimid_in2/)
+    call ezspline_defVar(ncid,trim(zpre)//'fspl',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   end if
-  if(ier.ne.0) return
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 94
+    return
+  end if
 
-  call cdfPutVar(ncid, trim(zpre)//'n1', spline_o%n1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'n2', spline_o%n2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'klookup1', spline_o%klookup1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'klookup2', spline_o%klookup2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isHermite', spline_o%isHermite, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isLinear', spline_o%isLinear, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isHybrid', spline_o%isHybrid, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isReady', spline_o%isReady, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'hspline', spline_o%hspline, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'ibctype1', spline_o%ibctype1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'ibctype2', spline_o%ibctype2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'x1', spline_o%x1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'x2', spline_o%x2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval1min', spline_o%bcval1min, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval1max', spline_o%bcval1max, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval2min', spline_o%bcval2min, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval2max', spline_o%bcval2max, ifail)
-  if(ifail/=0) then
-    ier=40
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%klookup1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'klookup2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%klookup2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHermite',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isHermite)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isLinear',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isLinear)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHybrid',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isHybrid)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isReady',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isReady)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'hspline',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%hspline)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ibctype1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ibctype2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval1min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval1max)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval2min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval2max)
+  if(ier.ne.NF90_NOERR) then
+    ier = 95
     return
   end if
 
   if(spline_o%isReady == 1) then
     if(.not.fullsv) then
-      call cdfPutVar(ncid, trim(zpre)//'f', spline_o%fspl(1,:,:), ifail)
+      ier = nf90_inq_varid(ncid,trim(zpre)//'f',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%fspl(1,:,:))
     else
-      call cdfPutVar(ncid, trim(zpre)//'x1min', spline_o%x1min, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x1max', spline_o%x1max, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'ilin1', spline_o%ilin1, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x2min', spline_o%x2min, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x2max', spline_o%x2max, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'ilin2', spline_o%ilin2, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x1pkg', spline_o%x1pkg, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x2pkg', spline_o%x2pkg, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'fspl', spline_o%fspl, ifail)
+      ier = nf90_inq_varid(ncid,trim(zpre)//'x1min',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1min)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1max',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1max)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin1',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ilin1)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2min',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2min)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2max',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2max)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin2',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ilin2)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1pkg',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1pkg)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2pkg',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2pkg)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'fspl',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%fspl)
     end if
+    if(ier.ne.NF90_NOERR) ier = 96
   else
-    ier = 93
+    ier = 96
   end if
+  if(ier.ne.0) return
 
-  call cdfCls(ncid)
-
-  if(ifail /=0) ier = 17
+  ier = nf90_close(ncid)
+  if(ier.ne.0) ier = 97
 
   return
 end subroutine EZspline_save2
@@ -306,42 +438,39 @@ end subroutine EZspline_save2
 !!!
 
 subroutine EZspline_save3(spline_o, filename, ier, spl_name, fullsave)
+  use psp_precision_mod, only: fp
   use EZspline_obj
-  use EZcdf
+  use netcdf
   implicit none
-  type(EZspline3) :: spline_o
-  character(len=*) :: filename
-  ! ier:
-  ! 17=could not save spline object in file filename
-  integer, intent(out) :: ier
-
+  type(EZspline3),  intent(in)  :: spline_o
+  character(len=*), intent(in)  :: filename
+  integer,          intent(out) :: ier
   !  if SPL_NAME is set, APPEND to file instead of creating new; prepend
   !  name to all NetCDF data items.  This allows one file to contain
-  !  multiple items. (new dmc Mar 2006)
+  !  multiple items.
   character(len=*), intent(in), optional :: spl_name  ! optional spline "name"
-
   !  if FULLSAVE is set .TRUE., save derived coefficients along with data
   !  this saves recalculating the coefficients when file is read (Mar 2006)
   logical, intent(in), optional :: fullsave
 
-  integer ncid, ifail, in0, in1, in2, in3
-  integer dimlens(3)
-  character(len=2), parameter :: real8='R8'
-  character(len=3), parameter :: int='INT'
+  integer :: ncid, in0, in1, in2, in3, ix2
+  integer :: varid
+  integer :: ndims
+  integer :: dimid_n1, dimid_n2, dimid_n3
+  integer :: dimid_nbcs
+  integer :: dimid_x2
+  integer :: dimid_in0, dimid_in1, dimid_in2, dimid_in3
+  integer :: dimid_hs
+  integer, dimension(3) :: dimids
 
   character(len=32) zpre
-  logical :: fullsv,imodify
+  logical :: fullsv, imodify
 
   ier = 0
-  if(spline_o%isReady /= 1) then
-    ier = 94
+  if(spline_o%isReady.ne.1) then
+    ier = 91
     return
   end if
-
-  in0 = size(spline_o%fspl,1)
-  in1 = size(spline_o%fspl,2)
-  in2 = size(spline_o%fspl,3)
-  in3 = size(spline_o%fspl,4)
 
   if(present(spl_name)) then
     call ezspline_spl_name_chk(spl_name,ier)
@@ -357,132 +486,219 @@ subroutine EZspline_save3(spline_o, filename, ier, spl_name, fullsave)
     fullsv=.FALSE.
   end if
 
+  in0 = size(spline_o%fspl,1)
+  in1 = size(spline_o%fspl,2)
+  in2 = size(spline_o%fspl,3)
+  in3 = size(spline_o%fspl,4)
+
+  if(fullsv) then
+    ix2 = size(spline_o%x1pkg,2)
+  end if
+
   if(zpre.eq.' ') then
-    call cdfOpn(ncid, filename, 'w') ! no error flag??
+    ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
     imodify=.FALSE.
   else
-    call cdfOpn(ncid, filename, 'v') ! Append if exists, else create new
+    ier = nf90_open(filename,NF90_WRITE,ncid)
+    if(ier.eq.NF90_NOERR) then
+      ier = nf90_redef(ncid)  ! start in "define mode".
+    else
+      ier = nf90_create(filename,IOR(NF90_CLOBBER,NF90_64BIT_OFFSET),ncid)
+    endif
     imodify=.TRUE.
   end if
-  if(ncid==0) then
-    ier = 39
+  if(ier.ne.NF90_NOERR .or. ncid.eq.0) then
+    ier = 92
     return
   end if
 
-  dimlens = (/1, 1, 1/) ! scalar
-  call ezspline_defVar(ncid, trim(zpre)//'n1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'n2', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'n3', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'klookup1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'klookup2', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'klookup3', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isHermite', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isLinear', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isHybrid', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'isReady', dimlens, int, imodify, ier)
-  dimlens = (/3, 1, 1/) 
-  call ezspline_defvar(ncid, trim(zpre)//'hspline', dimlens, int, imodify, ier)
-  dimlens = (/2, 1, 1/) 
-  call ezspline_defVar(ncid, trim(zpre)//'ibctype1', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'ibctype2', dimlens, int, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'ibctype3', dimlens, int, imodify, ier)
-  dimlens = (/spline_o%n1, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'x1', dimlens, real8, imodify, ier)
-  dimlens = (/spline_o%n2, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'x2', dimlens, real8, imodify, ier)
-  dimlens = (/spline_o%n3, 1, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'x3', dimlens, real8, imodify, ier)
-  dimlens = (/in2, in3, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval1min', dimlens, real8, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval1max', dimlens, real8, imodify, ier)
-  dimlens = (/in1, in3, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval2min', dimlens, real8, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval2max', dimlens, real8, imodify, ier)
-  dimlens = (/in1, in2, 1/)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval3min', dimlens, real8, imodify, ier)
-  call ezspline_defVar(ncid, trim(zpre)//'bcval3max', dimlens, real8, imodify, ier)
+  ier = NF90_NOERR
+  if(imodify) then
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'n1',dimid_n1)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'n2',dimid_n2)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'n3',dimid_n3)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'nbcs',dimid_nbcs)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in0',dimid_in0)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in1',dimid_in1)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in2',dimid_in2)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'in3',dimid_in3)
+    ier = nf90_inq_dimid(ncid,trim(zpre)//'hs',dimid_hs)
+    if(fullsv) then
+      ier = nf90_inq_dimid(ncid,trim(zpre)//'xnpkg',dimid_x2)
+    end if
+  end if
+  if(ier.ne.NF90_NOERR .or. .not.imodify) then
+    ier = nf90_def_dim(ncid,trim(zpre)//'n1',spline_o%n1,dimid_n1)
+    ier = nf90_def_dim(ncid,trim(zpre)//'n2',spline_o%n2,dimid_n2)
+    ier = nf90_def_dim(ncid,trim(zpre)//'n3',spline_o%n3,dimid_n3)
+    ier = nf90_def_dim(ncid,trim(zpre)//'nbcs',2,dimid_nbcs)
+    ier = nf90_def_dim(ncid,trim(zpre)//'in0',in0*in1,dimid_in0)
+    ier = nf90_def_dim(ncid,trim(zpre)//'in1',in1,dimid_in1)
+    ier = nf90_def_dim(ncid,trim(zpre)//'in2',in2,dimid_in2)
+    ier = nf90_def_dim(ncid,trim(zpre)//'in3',in3,dimid_in3)
+    ier = nf90_def_dim(ncid,trim(zpre)//'hs',3,dimid_hs)
+    if(fullsv) then
+      ier = nf90_def_dim(ncid,trim(zpre)//'xnpkg',ix2,dimid_x2)
+    end if
+  end if
+  if(ier.ne.NF90_NOERR) then
+    ier = 93
+    return
+  end if
+
+  ndims = 0
+  dimids = (/0, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'klookup1',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'klookup2',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'klookup3',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isHermite',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isLinear',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isHybrid',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'isReady',ndims,dimids,NF90_INT,imodify,varid,ier)
+  ndims = 1
+  dimids = (/dimid_hs, 0, 0/)
+  call ezspline_defvar(ncid,trim(zpre)//'hspline',ndims,dimids,NF90_INT,imodify,varid,ier)
+  dimids = (/dimid_nbcs, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'ibctype1',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'ibctype2',ndims,dimids,NF90_INT,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'ibctype3',ndims,dimids,NF90_INT,imodify,varid,ier)
+  dimids = (/dimid_n1, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'x1',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  dimids = (/dimid_n2, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'x2',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  dimids = (/dimid_n3, 0, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'x3',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  ndims = 2
+  dimids = (/dimid_in2, dimid_in3, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval1min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval1max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  dimids = (/dimid_in1, dimid_in3, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval2min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval2max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  dimids = (/dimid_in1, dimid_in2, 0/)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval3min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+  call ezspline_defVar(ncid,trim(zpre)//'bcval3max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   !
   ! save only the function values at the nodes
   !
-  dimlens = (/in1, in2, in3/)
   if(.not.fullsv) then
-    call ezspline_defVar(ncid, trim(zpre)//'f', dimlens, real8, imodify, ier)
+    ndims = 3
+    dimids = (/dimid_in1, dimid_in2, dimid_in3/)
+    call ezspline_defVar(ncid,trim(zpre)//'f',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   else
-    dimlens = (/1, 1, 1/) ! scalar
-    call ezspline_defVar(ncid, trim(zpre)//'x1min', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x1max', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'ilin1', dimlens, int, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x2min', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x2max', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'ilin2', dimlens, int, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x3min', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'x3max', dimlens, real8, imodify, ier)
-    call ezspline_defVar(ncid, trim(zpre)//'ilin3', dimlens, int, imodify, ier)
-    dimlens = (/spline_o%n1, 4, 1/)
-    call ezspline_defVar(ncid, trim(zpre)//'x1pkg', dimlens, real8, imodify, ier)
-    dimlens = (/spline_o%n2, 4, 1/)
-    call ezspline_defVar(ncid, trim(zpre)//'x2pkg', dimlens, real8, imodify, ier)
-    dimlens = (/spline_o%n3, 4, 1/)
-    call ezspline_defVar(ncid, trim(zpre)//'x3pkg', dimlens, real8, imodify, ier)
-    dimlens = (/in0*in1, in2, in3/)
-    call ezspline_defVar(ncid, trim(zpre)//'fspl', dimlens, real8, imodify, ier)
+    ndims = 0
+    dimids = (/0, 0, 0/) ! scalar
+    call ezspline_defVar(ncid,trim(zpre)//'x1min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x1max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'ilin1',ndims,dimids,NF90_INT,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x2min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x2max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'ilin2',ndims,dimids,NF90_INT,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x3min',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'x3max',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    call ezspline_defVar(ncid,trim(zpre)//'ilin3',ndims,dimids,NF90_INT,imodify,varid,ier)
+    ndims = 2
+    dimids = (/dimid_n1, dimid_x2, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'x1pkg',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    dimids = (/dimid_n2, dimid_x2, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'x2pkg',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    dimids = (/dimid_n3, dimid_x2, 0/)
+    call ezspline_defVar(ncid,trim(zpre)//'x3pkg',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
+    ndims = 3
+    dimids = (/dimid_in0, dimid_in2, dimid_in3/)
+    call ezspline_defVar(ncid,trim(zpre)//'fspl',ndims,dimids,NF90_DOUBLE,imodify,varid,ier)
   end if
-  if(ier.ne.0) return
+  if(ier.eq.NF90_NOERR) ier = nf90_enddef(ncid)
+  if(ier.ne.NF90_NOERR) then
+    ier = 94
+    return
+  end if
 
-  call cdfPutVar(ncid, trim(zpre)//'n1', spline_o%n1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'n2', spline_o%n2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'n3', spline_o%n3, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'klookup1', spline_o%klookup1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'klookup2', spline_o%klookup2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'klookup3', spline_o%klookup3, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isHermite', spline_o%isHermite, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isLinear', spline_o%isLinear, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isHybrid', spline_o%isHybrid, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'isReady', spline_o%isReady, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'hspline', spline_o%hspline, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'ibctype1', spline_o%ibctype1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'ibctype2', spline_o%ibctype2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'ibctype3', spline_o%ibctype3, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'x1', spline_o%x1, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'x2', spline_o%x2, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'x3', spline_o%x3, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval1min', spline_o%bcval1min, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval1max', spline_o%bcval1max, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval2min', spline_o%bcval2min, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval2max', spline_o%bcval2max, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval3min', spline_o%bcval3min, ifail)
-  call cdfPutVar(ncid, trim(zpre)//'bcval3max', spline_o%bcval3max, ifail)
-  if(ifail/=0) then
-    ier=40
+  ier = nf90_inq_varid(ncid,trim(zpre)//'klookup1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%klookup1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'klookup2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%klookup2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'klookup3',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%klookup3)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHermite',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isHermite)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isLinear',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isLinear)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isHybrid',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isHybrid)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'isReady',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%isReady)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'hspline',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%hspline)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ibctype1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ibctype2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ibctype3',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ibctype3)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x3)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval1min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval1max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval1max)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval2min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval2max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval2max)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval3min',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval3min)
+  if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'bcval3max',varid)
+  if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%bcval3max)
+  if(ier.ne.NF90_NOERR) then
+    ier=95
     return
   end if
 
   if(spline_o%isReady == 1) then
     if(.not.fullsv) then
-      call cdfPutVar(ncid, trim(zpre)//'f', spline_o%fspl(1,:,:,:), ifail)
+      ier = nf90_inq_varid(ncid,trim(zpre)//'f',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%fspl(1,:,:,:))
     else
-      call cdfPutVar(ncid, trim(zpre)//'x1min', spline_o%x1min, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x1max', spline_o%x1max, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'ilin1', spline_o%ilin1, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x2min', spline_o%x2min, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x2max', spline_o%x2max, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'ilin2', spline_o%ilin2, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x3min', spline_o%x3min, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x3max', spline_o%x3max, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'ilin3', spline_o%ilin3, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x1pkg', spline_o%x1pkg, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x2pkg', spline_o%x2pkg, ifail)
-      call cdfPutVar(ncid, trim(zpre)//'x3pkg', spline_o%x3pkg, ifail)
-      call ezspline_cdfput3(ncid, trim(zpre)//'fspl', spline_o%fspl, &
-           in0*in1, in2, in3, ifail)
+      ier = nf90_inq_varid(ncid,trim(zpre)//'x1min',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1min)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1max',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1max)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin1',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ilin1)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2min',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2min)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2max',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2max)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin2',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ilin2)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3min',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x3min)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3max',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x3max)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'ilin3',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%ilin3)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x1pkg',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x1pkg)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x2pkg',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x2pkg)
+      if(ier.eq.NF90_NOERR) ier = nf90_inq_varid(ncid,trim(zpre)//'x3pkg',varid)
+      if(ier.eq.NF90_NOERR) ier = nf90_put_var(ncid,varid,spline_o%x3pkg)
+      if(ier.eq.NF90_NOERR) &
+           call ezspline_cdfput3(ncid,trim(zpre)//'fspl',spline_o%fspl,in0*in1,in2,in3,ier)
     end if
+    if(ier.ne.NF90_NOERR) ier = 96
   else
-    ier = 93
+    ier = 96
   end if
+  if(ier.ne.0) return
 
-  call cdfCls(ncid)
-
-  if(ifail /=0) ier = 17
+  ier = nf90_close(ncid)
+  if(ier.ne.NF90_NOERR) ier = 97
 
   return
 end subroutine EZspline_save3
@@ -491,12 +707,10 @@ end subroutine EZspline_save3
 subroutine ezspline_spl_name_chk(spl_name,ier)
   character(len=*), intent(in) :: spl_name
   integer, intent(out) :: ier
-
-  !----------------
   integer :: ic,ilen,indx
   character(len=63) :: zlegal = &
        '0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-  !----------------
+
   ier=0
 
   ilen = len(trim(spl_name))
@@ -519,55 +733,58 @@ subroutine ezspline_spl_name_chk(spl_name,ier)
 
 end subroutine ezspline_spl_name_chk
 
-subroutine ezspline_defVar(ncid, name, dimlens, ztype, imodify, ier)
 
-  use EZcdf
-  implicit NONE
+subroutine ezspline_defVar(ncid, name, ndims, dimids, itype, lmodify, ivarid, ier)
+  use netcdf
+  implicit none
 
   ! inquire about variable with logic specific to ezspline_save
 
-  integer, intent(in) :: ncid          ! NetCDF handle
-  character(len=*), intent(in) :: name    ! item name to define
-  integer, intent(in) :: dimlens(3)    ! dimensioning information
-  character(len=*), intent(in) :: ztype   ! data type e.g. "R8"
-  logical, intent(in) :: imodify       ! T if item may already exist
+  integer, intent(in)               :: ncid    ! NetCDF handle
+  character(len=*), intent(in)      :: name    ! item name to define
+  integer, intent(in)               :: ndims   ! dimensioning information
+  integer, dimension(3), intent(in) :: dimids  ! dimensioning information
+  integer, intent(in)               :: itype   ! data type
+  logical, intent(in)               :: lmodify ! T if item may already exist
+  integer, intent(out)              :: ivarid  ! NetCDF variable id
+  integer, intent(inout)            :: ier
 
-  integer, intent(inout) :: ier        ! status code, set iff a real error
-  ! is detected...
+  integer               :: itype_loc
+  integer               :: ndims_loc
+  integer               :: id1,id2,ii
+  character(len=128)    :: name_loc
+  integer, dimension(3) :: dimids_loc
+  logical               :: lmodify_loc
 
-  !-----------------------------
-  character(len=10) :: ztype_loc
-  integer :: dimlens_loc(3),id1,id2,ii
-  integer :: ifail,ivarid
-  !-----------------------------
-
-  if(.not.imodify) then
-    ! simply define the quantity...
-    call cdfDefVar(ncid, name, dimlens, ztype, ifail)
-    if(ifail.ne.0) ier=42
-
-  else
-    ifail = nf_inq_varid(ncid, name, ivarid)
-    if(ifail.ne.0) then
-      ! assume item does not exist, so, just define it...
-      call cdfDefVar(ncid, name, dimlens, ztype, ifail)
-      if(ifail.ne.0) ier=42
+  if(.not.lmodify) lmodify_loc = .false.
+  if(lmodify) then
+    ier = nf90_inq_varid(ncid,name,ivarid)
+    if(ier.ne.NF90_NOERR) then
+      lmodify_loc = .false.
     else
-      ! item DOES exist; require dimension & type match...
-      call cdfInqVar(ncid, name, dimlens_loc, ztype_loc, ifail)
-      if(ztype.ne.ztype_loc) then
-        ier=53
+      lmodify_loc = .true.
+      ! item DOES exist; require dimension and type match...
+      ier = nf90_inquire_variable(ncid,ivarid,name_loc,xtype=itype_loc,ndims=ndims_loc)
+      if(itype.ne.itype_loc) ier = 51
+      if(ndims.ne.ndims_loc) then
+        ier = 52
       else
-        do ii=1,3
-          id1=max(1,dimlens(ii))
-          id2=max(1,dimlens_loc(ii))
-          if(id1.ne.id2) ier=53
+        do ii = 1, ndims
+          if(dimids(ii).ne.dimids_loc(ii)) ier = 53
         end do
       end if
-      !  if ier= 0, no cdfDefVar is needed: object already defined
-      !  and attributes are correct.
     end if
+  endif
+
+  if(.not.lmodify_loc) then
+    if(ndims.eq.0) then
+      ier = nf90_def_var(ncid,name,itype,ivarid)
+    else
+      ier = nf90_def_var(ncid,name,itype,dimids(1:ndims),ivarid)
+    end if
+    if(ier.ne.NF90_NOERR) ier=54
   end if
 
+  return
 end subroutine ezspline_defVar
 #endif

--- a/ezspline/ezspline_test.f90
+++ b/ezspline/ezspline_test.f90
@@ -12,117 +12,107 @@ program drive
 
   ier_count = 0
 
-  write(0,*)'***********************'
-  write(0,*)'* EZspline test drive *'
-  write(0,*)'***********************'
+  write(6,*)'***********************'
+  write(6,*)'* EZspline test drive *'
+  write(6,*)'***********************'
 
 
-  write(0,*)'This program performs 1-d, 2-d and 3-d data interpolation'
-  write(0,*)'and derivative evaluations based on both spline and Akima'
-  write(0,*)'Hermite representations. The Akima Hermite interpolation is'
-  write(0,*)'a Hermite interpolation for which the derivatives of the'
-  write(0,*)'function at the nodes are internally evaluated. Boundary '
-  write(0,*)'conditions such as "not-a-knot", periodic, 1st and 2nd '
-  write(0,*)'derivative imposed are tested, and so are interpolations'
-  write(0,*)'performed on a set of isolated points, on a cloud of points'
-  write(0,*)'and on a grid array of points (grid).'
-#ifdef _EZCDF
-  write(0,*)' '
-  write(0,*)'If you have MATLAB installed on your system, you can view'
-  write(0,*)'the interpolation results saved in the netCDF files *.nc'
-  write(0,*)'provided you also have access to MEXCDF, a netCDF to MATLAB'
-  write(0,*)'interface package freely available at'
-  write(0,*)'http://crusty.er.usgs.gov/~cdenham/MexCDF/nc4ml5.html'
-  write(0,*)'To run the MATLAB script ezspline_test.m, simply type'
-  write(0,*)'"ezspline_test" at the matlab prompt.'
-#endif
+  write(6,*)'This program performs 1-d, 2-d and 3-d data interpolation'
+  write(6,*)'and derivative evaluations based on both spline and Akima'
+  write(6,*)'Hermite representations. The Akima Hermite interpolation is'
+  write(6,*)'a Hermite interpolation for which the derivatives of the'
+  write(6,*)'function at the nodes are internally evaluated. Boundary '
+  write(6,*)'conditions such as "not-a-knot", periodic, 1st and 2nd '
+  write(6,*)'derivative imposed are tested, and so are interpolations'
+  write(6,*)'performed on a set of isolated points, on a cloud of points'
+  write(6,*)'and on a grid array of points (grid).'
 
-  write(0,*)''
-  write(0,*)'> 1-D splines'
-  write(0,*)''
-  write(0,*)'>> not-a-knot boundary conditions'
+  write(6,*)''
+  write(6,*)'> 1-D splines'
+  write(6,*)''
+  write(6,*)'>> not-a-knot boundary conditions'
   call spline1_not(ier)
   if(ier/=0) call err_count('**ERROR** in spline1_not')
-  write(0,*)'>> periodic boundary conditions'
+  write(6,*)'>> periodic boundary conditions'
   call spline1_per(ier)
   if(ier/=0) call err_count('**ERROR** in spline1_per')
-  write(0,*)'>> 1st derivative boundary conditions'
+  write(6,*)'>> 1st derivative boundary conditions'
   call spline1_1st(ier)
   if(ier/=0) call err_count('**ERROR** in spline1_1st')
-  write(0,*)'>> 2nd derivative boundary conditions'
+  write(6,*)'>> 2nd derivative boundary conditions'
   call spline1_2nd(ier)
   if(ier/=0) call err_count('**ERROR** in spline1_2nd')
 
-  write(0,*)''
-  write(0,*)'> 2-D splines'
-  write(0,*)''
-  write(0,*)'>> not-a-knot boundary conditions'
+  write(6,*)''
+  write(6,*)'> 2-D splines'
+  write(6,*)''
+  write(6,*)'>> not-a-knot boundary conditions'
   call spline2_not(ier)
   if(ier/=0) call err_count('**ERROR** in spline2_not')
-  write(0,*)'>> periodic boundary conditions'
+  write(6,*)'>> periodic boundary conditions'
   call spline2_per(ier)
   if(ier/=0) call err_count('**ERROR** in spline2_per')
-  write(0,*)'>> mixed boundary conditions'
+  write(6,*)'>> mixed boundary conditions'
   call spline2_mix(ier)
   if(ier/=0) call err_count('**ERROR** in spline2_mix')
 
-  write(0,*)''
-  write(0,*)'> 3-D splines'
-  write(0,*)''
-  write(0,*)'>> mixed boundary conditions'
+  write(6,*)''
+  write(6,*)'> 3-D splines'
+  write(6,*)''
+  write(6,*)'>> mixed boundary conditions'
   call spline3_mix(ier)
   if(ier/=0) call err_count('**ERROR** in spline3_mix')
-  write(0,*)'>> mixed boundary conditions 2'
+  write(6,*)'>> mixed boundary conditions 2'
   call spline3_mox(ier)
   if(ier/=0) call err_count('**ERROR** in spline3_mox')
 
-  write(0,*)''
-  write(0,*)'> 1-D Akima Hermite'
-  write(0,*)''
+  write(6,*)''
+  write(6,*)'> 1-D Akima Hermite'
+  write(6,*)''
   call akima1_not(ier)
   if(ier/=0) call err_count('**ERROR** in akima1_not')
-  write(0,*)'>> periodic boundary conditions'
+  write(6,*)'>> periodic boundary conditions'
   call akima1_per(ier)
   if(ier/=0) call err_count('**ERROR** in akima1_per')
 
-  write(0,*)''
-  write(0,*)'> 2-D Akima Hermite'
-  write(0,*)''
+  write(6,*)''
+  write(6,*)'> 2-D Akima Hermite'
+  write(6,*)''
   call akima2_not(ier)
   if(ier/=0) call err_count('**ERROR** in akima2_not')
-  write(0,*)'>> periodic boundary conditions'
+  write(6,*)'>> periodic boundary conditions'
   call akima2_per(ier)
   if(ier/=0) call err_count('**ERROR** in akima2_per')
 
-  write(0,*)''
-  write(0,*)'> 3-D Akima Hermite'
-  write(0,*)''
-  write(0,*)'>> mixed boundary conditions'
+  write(6,*)''
+  write(6,*)'> 3-D Akima Hermite'
+  write(6,*)''
+  write(6,*)'>> mixed boundary conditions'
   call akima3_mix(ier)
   if(ier/=0) call err_count('**ERROR** in akima3_mix')
 
-  write(0,*)''
-  write(0,*)'> 1-D Piecewise Linear'
-  write(0,*)''
+  write(6,*)''
+  write(6,*)'> 1-D Piecewise Linear'
+  write(6,*)''
   call pclin1(ier)
   if(ier/=0) call err_count('**ERROR** in pclin1')
 
-  write(0,*)''
-  write(0,*)'> 2-D Piecewise Linear'
-  write(0,*)''
+  write(6,*)''
+  write(6,*)'> 2-D Piecewise Linear'
+  write(6,*)''
   call pclin2(ier)
   if(ier/=0) call err_count('**ERROR** in pclin2')
 
-  write(0,*)''
-  write(0,*)'> 3-D Piecewise Linear'
-  write(0,*)''
+  write(6,*)''
+  write(6,*)'> 3-D Piecewise Linear'
+  write(6,*)''
   call pclin3(ier)
   if(ier/=0) call err_count('**ERROR** in pclin3')
 
   if(ier_count.eq.0) then
-     stop ' *successful end of EZspline test drive*'
+    write(6,*)' *successful end of EZspline test drive*'
   else
-     stop ' **ERRORS DETECTED** by end of EZspline test drive*'
+    write(6,*)' **ERRORS DETECTED** by end of EZspline test drive*'
   end if
 end program drive
 
@@ -135,7 +125,7 @@ subroutine err_count(msg)
   integer ier_count
   common/errors/ ier_count
 
-  write(0,*) msg
+  write(6,*) msg
   ier_count = ier_count + 1
 
 end subroutine err_count
@@ -165,7 +155,7 @@ subroutine spline1_not(ier)
   f = sin(x1)
 
   bcs1 = (/ 0, 0 /)
-  write(0,*)'grid size ',n1
+  write(6,*)'grid size ',n1
   call EZspline_init(spl, n1, bcs1, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -180,7 +170,7 @@ subroutine spline1_not(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-  write(0,*)' point interpolation (x, f, f-exact, error)'
+  write(6,*)' point interpolation (x, f, f-exact, error)'
   x1_point = spl%x1(1)
   call EZspline_isInDomain(spl,  x1_point, ier)
   call EZspline_error(ier)
@@ -189,24 +179,24 @@ subroutine spline1_not(ier)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = twopi/4.0_fp
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = spl%x1(spl%n1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
-  write(0,*)' cloud interpolation =>"spline1_not.nc" & "spline1_notx.nc" (exact)'
+  write(6,*)' cloud interpolation =>"spline1_not_.nc" & "spline1_notx.nc" (exact)'
   x1_cloud = twopi*(/ (real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   f_cloudx = sin(x1_cloud)
   call EZspline_isInDomain(spl, k1, x1_cloud, ier)
@@ -217,7 +207,7 @@ subroutine spline1_not(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF(k1, x1_cloud, f_cloud, 'spline1_not_.nc', ier)
   call EZspline_2netCDF(k1, x1_cloud, f_cloudx,'spline1_notx.nc', ier)
 #endif
@@ -247,7 +237,7 @@ subroutine spline1_per(ier)
   f = sin(x1)
 
   bcs1 = (/ -1, -1 /) 
-  write(0,*)'grid size ',n1
+  write(6,*)'grid size ',n1
   call EZspline_init(spl, n1, bcs1, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -258,37 +248,38 @@ subroutine spline1_per(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-  write(0,*)' point interpolation (x, f, f-exact, error)'
+  write(6,*)' point interpolation (x, f, f-exact, error)'
   x1_point = spl%x1(1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = twopi/4.0_fp
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = spl%x1(spl%n1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
-  write(0,*)' cloud interpolation => "spline1_per.nc" & "spline1_perx.nc" (exact)'
+  write(6,*)' cloud interpolation => "spline1_per_.nc" & "spline1_perx.nc" (exact)'
   x1_cloud = twopi*(/ (real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   call EZspline_interp(spl, k1, x1_cloud, f_cloud, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   f_cloudx = sin(x1_cloud)
   call EZspline_2netCDF( k1, x1_cloud, f_cloud, 'spline1_per_.nc', ier)
+  call EZspline_2netCDF( k1, x1_cloud, f_cloudx, 'spline1_perx.nc', ier)
 #endif
 
   call EZspline_free(spl, ier)
@@ -316,7 +307,7 @@ subroutine spline1_1st(ier)
   f = sin(x1)
 
   bcs1 = (/ 1, 1/)
-  write(0,*)'grid size ',n1
+  write(6,*)'grid size ',n1
   call EZspline_init(spl, n1, bcs1, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -329,36 +320,37 @@ subroutine spline1_1st(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-  write(0,*)' point interpolation (x, f, f-exact, error)'
+  write(6,*)' point interpolation (x, f, f-exact, error)'
   x1_point = spl%x1(1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = twopi/4.0_fp
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = spl%x1(spl%n1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
-  write(0,*)' cloud interpolation => "spline1_1st.nc" & "spline_1stx.nc" (exact)'
+  write(6,*)' cloud interpolation => "spline1_1st.nc" & "spline_1stx.nc" (exact)'
   x1_cloud = twopi*(/ (real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   call EZspline_interp(spl, k1, x1_cloud, f_cloud, ier)
   call EZspline_error(ier)
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   f_cloudx = sin(x1_cloud)
   call EZspline_2netCDF(k1, x1_cloud, f_cloud, 'spline1_1st_.nc', ier)
+  call EZspline_2netCDF(k1, x1_cloud, f_cloudx, 'spline1_1stx.nc', ier)
 #endif
 
   call EZspline_free(spl, ier)
@@ -387,7 +379,7 @@ subroutine spline1_2nd(ier)
   f = sin(x1)
 
   bcs1 = (/ 2, 2/)
-  write(0,*)'grid size ',n1
+  write(6,*)'grid size ',n1
   call EZspline_init(spl, n1, bcs1, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -400,65 +392,66 @@ subroutine spline1_2nd(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-  write(0,*)' point interpolation (x, f, f-exact, error)'
+  write(6,*)' point interpolation (x, f, f-exact, error)'
   x1_point = spl%x1(1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = twopi/4.0_fp
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = spl%x1(spl%n1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
-  write(0,*)' cloud interpolation => "spline1_2nd.nc" & "spline1_2nd.nc" (exact)'
+  write(6,*)' cloud interpolation => "spline1_2nd.nc" & "spline1_2ndx.nc" (exact)'
   x1_cloud = twopi*(/ (real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   call EZspline_interp(spl, k1, x1_cloud, f_cloud, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   f_cloudx = sin(x1_cloud)
   call Ezspline_2netCDF( k1, x1_cloud, f_cloud, 'spline1_2nd_.nc', ier)
+  call Ezspline_2netCDF( k1, x1_cloud, f_cloudx, 'spline1_2ndx.nc', ier)
 #endif
 
-  write(0,*)' point derivative (x, fx, fx-exact, error)'
+  write(6,*)' point derivative (x, fx, fx-exact, error)'
   x1_point  = twopi/2.23987563_fp
   fx_pointx = cos(x1_point)
   call EZspline_derivative(spl, 1, x1_point, fx_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, fx_point, fx_pointx, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, fx_point, fx_pointx, &
        fx_point - fx_pointx
 
-  write(0,*)' point derivative (x, fxx, fxx-exact, error)'
+  write(6,*)' point derivative (x, fxx, fxx-exact, error)'
   fxx_pointx = -sin(x1_point)
   call EZspline_derivative(spl, 2, x1_point, fxx_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, fxx_point, fxx_pointx, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, fxx_point, fxx_pointx, &
        fxx_point - fxx_pointx
 
-  write(0,*)' gradient  (x, fx)'
+  write(6,*)' gradient  (x, fx)'
   call EZspline_gradient(spl, x1_point, df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(2f10.6)') x1_point, df
-  write(0,'(2f10.6)') x1_point, fx_pointx
+  write(6,'(2f10.6)') x1_point, df
+  write(6,'(2f10.6)') x1_point, fx_pointx
 
-#ifdef _EZCDF
-  write(0,*)'save 1-D spline object in file "spline1.nc"'
+#ifdef _NETCDF
+  write(6,*)'save 1-D spline object in file "spline1.nc"'
   call EZspline_save(spl,"spline1.nc", ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -472,8 +465,8 @@ subroutine spline1_2nd(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
   if(df.ne.tmp) then
-     write(0,*) ' ==> EZspline_gradient value change after save/load sequence:'
-     write(0,'("     before, after: ",2(f10.6))') tmp,df
+     write(6,*) ' ==> EZspline_gradient value change after save/load sequence:'
+     write(6,'("     before, after: ",2(f10.6))') tmp,df
   end if
 #endif
 
@@ -481,6 +474,7 @@ subroutine spline1_2nd(ier)
   call EZspline_error(ier)
 
 end subroutine spline1_2nd
+
 
 !! 
 !! 2-D SPLINE
@@ -520,12 +514,12 @@ subroutine spline2_not(ier)
       x_pt = (1.0_fp + cos( x1(i) ))*cos( x2(j) )
       y_pt = (1.0_fp + cos( x1(i) ))*sin( x2(j) )
       f(i,j) = (x_pt-1.0_fp)**2 + y_pt**2
-    enddo
-  enddo
+    end do
+  end do
 
   bcs1 = (/ 0, 0/) ! not a knot
   bcs2 = (/ 0, 0/) ! not a knot
-  write(0,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
+  write(6,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
   call EZspline_init(spl, n1, n2, bcs1, bcs2, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -540,7 +534,7 @@ subroutine spline2_not(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x_pt = (1.0_fp + cos( x1_point ))*cos( x2_point )
@@ -553,10 +547,10 @@ subroutine spline2_not(ier)
   call EZspline_interp(spl, x1_point, x2_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "spline2_not_c.nc" & "spline2_not_cx.nc" (exact)'
+  write(6,*)' cloud interpolation => "spline2_not_c_.nc" & "spline2_not_cx.nc" (exact)'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -571,12 +565,12 @@ subroutine spline2_not(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloud, "spline2_not__c.nc", ier)
-  call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloudx,"spline2_notx_c.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloud, "spline2_not_c_.nc", ier)
+  call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloudx,"spline2_not_cx.nc", ier)
 #endif
 
-  write(0,*)' array interpolation  => "spline2_not_a.nc" & "spline2_not_ax.nc" (exact)'
+  write(6,*)' array interpolation  => "spline2_not_a.nc" & "spline2_not_ax.nc" (exact)'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -588,8 +582,8 @@ subroutine spline2_not(ier)
            cos( x1_array(i) ))*cos( x2_array(j)) - 1.0_fp )**2 &
            + ( (1.0_fp + &
            cos( x1_array(i) ))*sin( x2_array(j) ) )**2 
-    enddo
-  enddo
+    end do
+  end do
   call EZspline_isInDomain(spl,  k1, k2, x1_array, x2_array, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -597,59 +591,59 @@ subroutine spline2_not(ier)
   call EZspline_interp(spl, k1, k2, x1_array, x2_array, f_array, ier)
   call EZspline_error(ier)
 
-#ifdef _EZCDF
-  call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_array, "spline2_not__a.nc", ier)
-  call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_arrayx,"spline2_notx_a.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_array, "spline2_not_a_.nc", ier)
+  call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_arrayx,"spline2_not_ax.nc", ier)
 #endif
 
-  write(0,*)' point derivative (x, y, fx, fx-exact, error)'
+  write(6,*)' point derivative (x, y, fx, fx-exact, error)'
   fx_pointx = -2.0_fp*(1.0_fp + cos(x1_point) - cos(x2_point))*sin(x1_point)
   call EZspline_derivative(spl, 1, 0, x1_point, x2_point, fx_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fx_point, fx_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fx_point, fx_pointx, &
        fx_point - fx_pointx
 
-  write(0,*)' point derivative (x, y, fy, fy-exact, error)'
+  write(6,*)' point derivative (x, y, fy, fy-exact, error)'
   fy_pointx = 2.0_fp*(1.0_fp + cos(x1_point))*sin(x2_point)
   call EZspline_derivative(spl, 0, 1, x1_point, x2_point, fy_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fy_point, fy_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fy_point, fy_pointx, &
        fy_point - fy_pointx
 
-  write(0,*)' point derivative (x, y, fxx, fxx-exact, error)'
+  write(6,*)' point derivative (x, y, fxx, fxx-exact, error)'
   fxx_pointx = -2.0_fp*(cos(x1_point) + cos(2.0_fp*x1_point) - cos(x1_point)*cos(x2_point))
   call EZspline_derivative(spl, 2, 0, x1_point, x2_point, fxx_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fxx_point, fxx_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fxx_point, fxx_pointx, &
        fxx_point - fxx_pointx
 
-  write(0,*)' point derivative (x, y, fyy, fyy-exact, error)'
+  write(6,*)' point derivative (x, y, fyy, fyy-exact, error)'
   fyy_pointx = 2.0_fp*(1.0_fp + cos(x1_point))*cos(x2_point)
   call EZspline_derivative(spl, 0, 2, x1_point, x2_point, fyy_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fyy_point, fyy_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fyy_point, fyy_pointx, &
        fyy_point - fyy_pointx
 
-  write(0,*)' point derivative (x, y, fxy, fxy-exact, error)'
+  write(6,*)' point derivative (x, y, fxy, fxy-exact, error)'
   fxy_pointx = -2.0_fp*sin(x1_point)*sin(x2_point)
   call EZspline_derivative(spl, 1, 1, x1_point, x2_point, fxy_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fxy_point, fxy_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fxy_point, fxy_pointx, &
        fxy_point - fxy_pointx
 
-  write(0,'(a,2f10.6)')' gradient (x, y, fx, fy)'
+  write(6,'(a,2f10.6)')' gradient (x, y, fx, fy)'
   call EZspline_gradient(spl, x1_point, x2_point, &
        df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return  
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, df(1), df(2)
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, fx_pointx, fy_pointx
 
   call EZspline_free(spl, ier)
@@ -690,12 +684,12 @@ subroutine spline2_per(ier)
       x_pt = (1.0_fp + cos( x1(i) ))*cos( x2(j) )
       y_pt = (1.0_fp + cos( x1(i) ))*sin( x2(j) )
       f(i,j) = (x_pt-1.0_fp)**2 + y_pt**2
-    enddo
-  enddo
+    end do
+  end do
 
   bcs1 = (/ -1, -1/) ! periodic
   bcs2 = (/ -1, -1/) ! periodic
-  write(0,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
+  write(6,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
   call EZspline_init(spl, n1, n2, bcs1, bcs2, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -706,7 +700,7 @@ subroutine spline2_per(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x_pt = (1.0_fp + cos( x1_point ))*cos( x2_point )
@@ -715,10 +709,10 @@ subroutine spline2_per(ier)
   call EZspline_interp(spl, x1_point, x2_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "spline2_per_c.nc" & "spline2_per_cx.nc"'
+  write(6,*)' cloud interpolation => "spline2_per_c_.nc" & "spline2_per_cx.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -729,11 +723,12 @@ subroutine spline2_per(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloud, "spline2_per__c.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloud, "spline2_per_c_.nc", ier)
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloudx, "spline2_per_cx.nc", ier)
 #endif
 
-  write(0,*)' array interpolation "spline2_per_a.nc" & "spline2_per_ax.nc"'
+  write(6,*)' array interpolation "spline2_per_a_.nc" & "spline2_per_ax.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -745,14 +740,15 @@ subroutine spline2_per(ier)
            cos( x1_array(i) ))*cos( x2_array(j)) - 1.0_fp )**2 &
            + ( (1.0_fp + &
            cos( x1_array(i) ))*sin( x2_array(j) ) )**2 
-    enddo
-  enddo
+    end do
+  end do
   call EZspline_interp(spl, k1, k2, x1_array, x2_array, f_array, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_array, "spline2_per__a.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_array, "spline2_per_a_.nc", ier)
+  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_arrayx, "spline2_per_ax.nc", ier)
 #endif
 
   call EZspline_free(spl, ier)
@@ -793,12 +789,12 @@ subroutine spline2_mix(ier)
       x_pt = (1.0_fp + cos( x1(i) ))*cos( x2(j) )
       y_pt = (1.0_fp + cos( x1(i) ))*sin( x2(j) )
       f(i,j) = (x_pt-1.0_fp)**2 + y_pt**2
-    enddo
-  enddo
+    end do
+  end do
 
   bcs1 = (/ 1, 2/) ! fx on left, fxx on right
   bcs2 = (/2, 1/)
-  write(0,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
+  write(6,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
   call EZspline_init(spl, n1, n2, bcs1, bcs2, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -815,7 +811,7 @@ subroutine spline2_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x_pt = (1.0_fp + cos( x1_point ))*cos( x2_point )
@@ -824,10 +820,10 @@ subroutine spline2_mix(ier)
   call EZspline_interp(spl, x1_point, x2_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "spline2_mix_c.nc" & "spline2_mix_cx.nc"'
+  write(6,*)' cloud interpolation => "spline2_mix_c_.nc" & "spline2_mix_cx.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
 
@@ -842,11 +838,12 @@ subroutine spline2_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloud, "spline2_mix__c.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloud, "spline2_mix_c_.nc", ier)
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloudx, "spline2_mix_cx.nc", ier)
 #endif
 
-  write(0,*)' array interpolation "spline2_mix_a.nc" & "spline2_mix_ax.nc"'
+  write(6,*)' array interpolation "spline2_mix_a_.nc" & "spline2_mix_ax.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -858,16 +855,19 @@ subroutine spline2_mix(ier)
            cos( x1_array(i) ))*cos( x2_array(j)) - 1.0_fp )**2 &
            + ( (1.0_fp + &
            cos( x1_array(i) ))*sin( x2_array(j) ) )**2 
-    enddo
-  enddo
+    end do
+  end do
   call EZspline_interp(spl, k1, k2, x1_array, x2_array, f_array, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_array, "spline2_mix__a.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_array, "spline2_mix_a_.nc", ier)
+  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_arrayx, "spline2_mix_ax.nc", ier)
+#endif
 
-  write(0,*)'save spline object in file "spline2.nc"'
+#ifdef _NETCDF
+  write(6,*)'save spline object in file "spline2.nc"'
   call EZspline_save(spl, "spline2.nc", ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -882,10 +882,10 @@ subroutine spline2_mix(ier)
   do j = 1, k2
     do i = 1, k1
       if(tmp_array(i,j).ne.f_array(i,j)) then 
-        write(0,'(" => save/reload value changed: (",i2,",",i2,"): ",2(f10.6))') i,j,f_array(i,j),tmp_array(i,j)
-      endif
-    enddo
-  enddo
+        write(6,'(" => save/reload value changed: (",i2,",",i2,"): ",2(f10.6))') i,j,f_array(i,j),tmp_array(i,j)
+      end if
+    end do
+  end do
 #endif
 
   call EZspline_free(spl, ier)
@@ -932,14 +932,14 @@ subroutine spline3_mix(ier)
         y_pt = (1.0_fp + x3(k)*cos( x1(i) ))*sin( x2(j) )
         z_pt = x3(k)*sin( x1(i) )
         f(i,j,k) = (x_pt-1.0_fp)**2 + y_pt**2 + z_pt**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
 
   bcs1 = (/ -1, -1 /) ! periodic
   bcs2 = (/ -1, -1 /) ! periodic
   bcs3 = (/  0,  0 /) ! not a knot
-  write(0,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
+  write(6,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
   call EZspline_init(spl, n1, n2, n3, bcs1, bcs2, bcs3, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -955,7 +955,7 @@ subroutine spline3_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, z, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, z, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x3_point = spl%x3min + (spl%x3max-spl%x3min)/4.93642_fp
@@ -970,10 +970,10 @@ subroutine spline3_mix(ier)
   call EZspline_interp(spl, x1_point, x2_point, x3_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
+  write(6,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "spline3_mix_c.nc" & "spline3_mix_cx.nc"'
+  write(6,*)' cloud interpolation => "spline3_mix_c.nc" & "spline3_mix_cx.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -991,14 +991,14 @@ subroutine spline3_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloud, &
-       "spline3_mix__c.nc", ier)
+       "spline3_mix_c_.nc", ier)
   call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloudx, &
        "spline3_mix_cx.nc", ier)
 #endif
 
-  write(0,*)' array interpolation => "spline3_mix_a.nc" & "spline3_mix_ax.nc"'
+  write(6,*)' array interpolation => "spline3_mix_a.nc" & "spline3_mix_ax.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1014,9 +1014,9 @@ subroutine spline3_mix(ier)
              + ( (1.0_fp + &
              x3_array(k)*cos( x1_array(i) ))*sin( x2_array(j) ) )**2 &
              + ( x3_array(k)*sin( x1_array(i) ) )**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
   call EZspline_isInDomain(spl, k1, k2, k3, x1_array, x2_array, x3_array, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1025,13 +1025,15 @@ subroutine spline3_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_array,&
-       "spline3_mix__a.nc", ier)
-  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_arrayx,&
+#ifdef _NETCDF
+  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_array, &
+       "spline3_mix_a_.nc", ier)
+  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_arrayx, &
        "spline3_mix_ax.nc", ier)
+#endif
 
-  write(0,*)'save spline object in file "spline3.nc"'
+#ifdef _NETCDF
+  write(6,*)'save spline object in file "spline3.nc"'
   call EZspline_save(spl, "spline3.nc", ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1047,12 +1049,12 @@ subroutine spline3_mix(ier)
     do j = 1, k2
       do i = 1, k1
         if(tmp_array(i,j,k).ne.f_array(i,j,k)) then 
-          write(0,'(" => save/reload value changed: (",i2,",",i2,",",i2,"): ")') i,j,k
-          write(0,'(10x,2(f10.6,1x))') f_array(i,j,k),tmp_array(i,j,k)
-        endif
-      enddo
-    enddo
-  enddo
+          write(6,'(" => save/reload value changed: (",i2,",",i2,",",i2,"): ")') i,j,k
+          write(6,'(10x,2(f10.6,1x))') f_array(i,j,k),tmp_array(i,j,k)
+        end if
+      end do
+    end do
+  end do
 #endif
 
   call EZspline_free(spl, ier)
@@ -1097,14 +1099,14 @@ subroutine spline3_mox(ier)
         y_pt = (1.0_fp + x3(k)*cos( x1(i) ))*sin( x2(j) )
         z_pt = x3(k)*sin( x1(i) )
         f(i,j,k) = (x_pt-1.0_fp)**2 + y_pt**2 + z_pt**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
 
   bcs1 = (/1, 2/) ! fx, fxx
   bcs2 = (/2, 2/) ! fyy, fyy
   bcs3 = (/1, 1/) ! fz, fz
-  write(0,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
+  write(6,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
   call EZspline_init(spl, n1, n2, n3, bcs1, bcs2, bcs3, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1142,7 +1144,7 @@ subroutine spline3_mox(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, z, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, z, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x3_point = spl%x3min + (spl%x3max-spl%x3min)/4.93642_fp
@@ -1153,25 +1155,25 @@ subroutine spline3_mox(ier)
   call EZspline_interp(spl, x1_point, x2_point, x3_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
+  write(6,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,'(a,3f10.6)')' gradient (x, y, z, fx, fy, fz)'
+  write(6,'(a,3f10.6)')' gradient (x, y, z, fx, fy, fz)'
   call EZspline_gradient(spl, x1_point, x2_point, x3_point, &
        df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(10f10.6)') x1_point, x2_point, x3_point, &
+  write(6,'(10f10.6)') x1_point, x2_point, x3_point, &
        df(1), df(2), df(3)
   !compute exact values
   df(1)= -4.0_fp*x3_point*sin(x1_point)*sin(x2_point/2.0_fp)**2
   df(2)= 2.0_fp*(1.0_fp + x3_point*cos(x1_point))*sin(x2_point)
   df(3)= 2.0_fp*x3_point + 2.0_fp*cos(x1_point) - &
        cos(x1_point - x2_point) - cos(x1_point + x2_point)
-  write(0,'(10f10.6)') x1_point, x2_point, x3_point, &
+  write(6,'(10f10.6)') x1_point, x2_point, x3_point, &
        df(1), df(2), df(3)
 
-  write(0,*)' cloud interpolation => "spline3_mox__c.nc" & "spline3_mox_cx.nc"'
+  write(6,*)' cloud interpolation => "spline3_mox_c_.nc" & "spline3_mox_cx.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1185,12 +1187,14 @@ subroutine spline3_mox(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloud, &
-       "spline3_mox__c.nc", ier)
+       "spline3_mox_c_.nc", ier)
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloudx, &
+       "spline3_mox_cx.nc", ier)
 #endif
 
-  write(0,*)' array interpolation => "spline3_mox__a.nc" & "spline3_mox_ax.nc"'
+  write(6,*)' array interpolation => "spline3_mox_a_.nc" & "spline3_mox_ax.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1206,16 +1210,18 @@ subroutine spline3_mox(ier)
              + ( (1.0_fp + &
              x3_array(k)*cos( x1_array(i) ))*sin( x2_array(j) ) )**2 &
              + ( x3_array(k)*sin( x1_array(i) ) )**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
   call EZspline_interp(spl, k1, k2, k3, x1_array, x2_array, x3_array, f_array, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_array, &
-       'spline3_mox__a.nc',ier)
+       'spline3_mox_ax.nc',ier)
+  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_arrayx, &
+       'spline3_mox_ax.nc',ier)
 #endif
 
   call EZspline_free(spl, ier)
@@ -1250,7 +1256,7 @@ subroutine akima1_not(ier)
   f = sin(x1)
 
   bcs1 = (/ 0, 0 /)
-  write(0,*)'grid size ',n1
+  write(6,*)'grid size ',n1
   call EZspline_init(spl, n1, bcs1, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -1268,7 +1274,7 @@ subroutine akima1_not(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-  write(0,*)' point interpolation (x, f, f-exact, error)'
+  write(6,*)' point interpolation (x, f, f-exact, error)'
   x1_point = spl%x1(1)
   call EZspline_isInDomain(spl,  x1_point, ier)
   call EZspline_error(ier)
@@ -1277,24 +1283,24 @@ subroutine akima1_not(ier)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = twopi/4.0_fp
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = spl%x1(spl%n1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
-  write(0,*)' cloud interpolation =>"akima1__not.nc"'
+  write(6,*)' cloud interpolation =>"akima1__not.nc"'
   x1_cloud = twopi*(/ (real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   f_cloudx = sin(x1_cloud)
   call EZspline_isInDomain(spl, k1, x1_cloud, ier)
@@ -1306,15 +1312,16 @@ subroutine akima1_not(ier)
   if(ier /=0 ) return
 
 
-  write(0,*)' gradient  (x, fx)'
+  write(6,*)' gradient  (x, fx)'
   call EZspline_gradient(spl, x1_point, df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(2f10.6)') x1_point, df
-  write(0,'(2f10.6)') x1_point, cos(x1_point)
+  write(6,'(2f10.6)') x1_point, df
+  write(6,'(2f10.6)') x1_point, cos(x1_point)
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k1, x1_cloud, f_cloud, "akima1__not.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k1, x1_cloud, f_cloud, "akima1_not_.nc", ier)
+  call EZspline_2netCDF(k1, x1_cloud, f_cloudx, "akima1_notx.nc", ier)
 #endif
 
   call EZspline_free(spl, ier)
@@ -1343,7 +1350,7 @@ subroutine akima1_per(ier)
   f = sin(x1)
 
   bcs1 = (/ -1, -1 /) 
-  write(0,*)'grid size ',n1
+  write(6,*)'grid size ',n1
   call EZspline_init(spl, n1, bcs1, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -1357,44 +1364,45 @@ subroutine akima1_per(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-  write(0,*)' point interpolation (x, f, f-exact, error)'
+  write(6,*)' point interpolation (x, f, f-exact, error)'
   x1_point = spl%x1(1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = twopi/4.0_fp
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = spl%x1(spl%n1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
-  write(0,*)' gradient  (x, fx)'
+  write(6,*)' gradient  (x, fx)'
   call EZspline_gradient(spl, x1_point, df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(2f10.6)') x1_point, df
-  write(0,'(2f10.6)') x1_point, cos(x1_point)
+  write(6,'(2f10.6)') x1_point, df
+  write(6,'(2f10.6)') x1_point, cos(x1_point)
 
-  write(0,*)' cloud interpolation => "akima1__per.nc"'
+  write(6,*)' cloud interpolation => "akima1__per.nc"'
   x1_cloud = twopi*(/ (real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   call EZspline_interp(spl, k1, x1_cloud, f_cloud, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   f_cloudx = sin(x1_cloud)
-  call EZspline_2netCDF( k1, x1_cloud, f_cloud, "akima1__per.nc", ier)
+  call EZspline_2netCDF( k1, x1_cloud, f_cloud, "akima1_per_.nc", ier)
+  call EZspline_2netCDF( k1, x1_cloud, f_cloudx, "akima1_perx.nc", ier)
 #endif
 
   call EZspline_free(spl, ier)
@@ -1441,12 +1449,12 @@ subroutine akima2_not(ier)
       x_pt = (1.0_fp + cos( x1(i) ))*cos( x2(j) )
       y_pt = (1.0_fp + cos( x1(i) ))*sin( x2(j) )
       f(i,j) = (x_pt-1.0_fp)**2 + y_pt**2
-    enddo
-  enddo
+    end do
+  end do
 
   bcs1 = (/ 0, 0/) ! not a knot
   bcs2 = (/ 0, 0/) ! not a knot
-  write(0,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
+  write(6,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
   call EZspline_init(spl, n1, n2, bcs1, bcs2, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1464,7 +1472,7 @@ subroutine akima2_not(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x_pt = (1.0_fp + cos( x1_point ))*cos( x2_point )
@@ -1477,10 +1485,10 @@ subroutine akima2_not(ier)
   call EZspline_interp(spl, x1_point, x2_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "akima2_not__c.nc"'
+  write(6,*)' cloud interpolation => "akima2_not__c.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1495,11 +1503,12 @@ subroutine akima2_not(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloud, "akima2_not__c.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloud, "akima2_not_c_.nc", ier)
+  call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloudx, "akima2_not_cc.nc", ier)
 #endif
 
-  write(0,*)' array interpolation  => "akima2_not__a.nc"'
+  write(6,*)' array interpolation  => "akima2_not__a.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1511,8 +1520,8 @@ subroutine akima2_not(ier)
            cos( x1_array(i) ))*cos( x2_array(j)) - 1.0_fp )**2 &
            + ( (1.0_fp + &
            cos( x1_array(i) ))*sin( x2_array(j) ) )**2 
-    enddo
-  enddo
+    end do
+  end do
   call EZspline_isInDomain(spl,  k1, k2, x1_array, x2_array, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -1520,34 +1529,35 @@ subroutine akima2_not(ier)
   call EZspline_interp(spl, k1, k2, x1_array, x2_array, f_array, ier)
   call EZspline_error(ier)
 
-#ifdef _EZCDF
-  call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_array, "akima2_not__a.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_array, "akima2_not_a_.nc", ier)
+  call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_arrayx, "akima2_not_ax.nc", ier)
 #endif
 
-  write(0,*)' point derivative (x, y, fx, fx-exact, error)'
+  write(6,*)' point derivative (x, y, fx, fx-exact, error)'
   fx_pointx = -2.0_fp*(1.0_fp + cos(x1_point) - cos(x2_point))*sin(x1_point)
   call EZspline_derivative(spl, 1, 0, x1_point, x2_point, fx_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fx_point, fx_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fx_point, fx_pointx, &
        fx_point - fx_pointx
 
-  write(0,*)' point derivative (x, y, fy, fy-exact, error)'
+  write(6,*)' point derivative (x, y, fy, fy-exact, error)'
   fy_pointx = 2.0_fp*(1.0_fp + cos(x1_point))*sin(x2_point)
   call EZspline_derivative(spl, 0, 1, x1_point, x2_point, fy_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fy_point, fy_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fy_point, fy_pointx, &
        fy_point - fy_pointx
 
-  write(0,'(a,2f10.6)')' gradient (x, y, fx, fy)'
+  write(6,'(a,2f10.6)')' gradient (x, y, fx, fy)'
   call EZspline_gradient(spl, x1_point, x2_point, &
        df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return  
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, df(1), df(2)
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, fx_pointx, fy_pointx
 
 
@@ -1591,12 +1601,12 @@ subroutine akima2_per(ier)
       x_pt = (1.0_fp + cos( x1(i) ))*cos( x2(j) )
       y_pt = (1.0_fp + cos( x1(i) ))*sin( x2(j) )
       f(i,j) = (x_pt-1.0_fp)**2 + y_pt**2
-    enddo
-  enddo
+    end do
+  end do
 
   bcs1 = (/ -1, -1/) ! periodic
   bcs2 = (/ -1, -1/) ! periodic
-  write(0,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
+  write(6,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
   call EZspline_init(spl, n1, n2, bcs1, bcs2, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1611,7 +1621,7 @@ subroutine akima2_per(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x_pt = (1.0_fp + cos( x1_point ))*cos( x2_point )
@@ -1620,10 +1630,10 @@ subroutine akima2_per(ier)
   call EZspline_interp(spl, x1_point, x2_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "akima2_per__c.nc"'
+  write(6,*)' cloud interpolation => "akima2_per__c.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1634,11 +1644,12 @@ subroutine akima2_per(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloud, 'akima2_per__c.nc', ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloud, 'akima2_per_c_.nc', ier)
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, f_cloudx, 'akima2_per_cx.nc', ier)
 #endif
 
-  write(0,*)' array interpolation "akima2_per__a.nc"'
+  write(6,*)' array interpolation "akima2_per__a.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1650,26 +1661,27 @@ subroutine akima2_per(ier)
            cos( x1_array(i) ))*cos( x2_array(j)) - 1.0_fp )**2 &
            + ( (1.0_fp + &
            cos( x1_array(i) ))*sin( x2_array(j) ) )**2 
-    enddo
-  enddo
+    end do
+  end do
   call EZspline_interp(spl, k1, k2, x1_array, x2_array, f_array, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_array, 'akima2_per__a.nc', ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_array, 'akima2_per_a_.nc', ier)
+  call EZspline_2netCDF(k1, k2, x1_array, x2_array, f_arrayx, 'akima2_per_ax.nc', ier)
 #endif
 
-  write(0,'(a,2f10.6)')' gradient (x, y, fx, fy)'
+  write(6,'(a,2f10.6)')' gradient (x, y, fx, fy)'
   call EZspline_gradient(spl, x1_point, x2_point, &
        df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return  
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, df(1), df(2)
   fx_pointx = -2.0_fp*(1.0_fp + cos(x1_point) - cos(x2_point))*sin(x1_point)
   fy_pointx = 2.0_fp*(1.0_fp + cos(x1_point))*sin(x2_point)
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, fx_pointx, fy_pointx
 
   call EZspline_free(spl, ier)
@@ -1719,14 +1731,14 @@ subroutine akima3_mix(ier)
         y_pt = (1.0_fp + x3(k)*cos( x1(i) ))*sin( x2(j) )
         z_pt = x3(k)*sin( x1(i) )
         f(i,j,k) = (x_pt-1.0_fp)**2 + y_pt**2 + z_pt**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
 
   bcs1 = (/ -1, -1 /) ! periodic
   bcs2 = (/ -1, -1 /) ! periodic
   bcs3 = (/  0,  0 /) ! not a knot
-  write(0,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
+  write(6,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
   call EZspline_init(spl, n1, n2, n3, bcs1, bcs2, bcs3, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1745,7 +1757,7 @@ subroutine akima3_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, z, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, z, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x3_point = spl%x3min + (spl%x3max-spl%x3min)/4.93642_fp
@@ -1760,10 +1772,10 @@ subroutine akima3_mix(ier)
   call EZspline_interp(spl, x1_point, x2_point, x3_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
+  write(6,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "akima3_mix__c.nc"'
+  write(6,*)' cloud interpolation => "akima3_mix__c.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1781,12 +1793,12 @@ subroutine akima3_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloud, &
-       "akima3_mix__c.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloud, "akima3_mix_c_.nc", ier)
+  call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloudx, "akima3_mix_cc.nc", ier)
 #endif
 
-  write(0,*)' array interpolation => "akima3_mix__a.nc"'
+  write(6,*)' array interpolation => "akima3_mix__a.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -1802,9 +1814,9 @@ subroutine akima3_mix(ier)
              + ( (1.0_fp + &
              x3_array(k)*cos( x1_array(i) ))*sin( x2_array(j) ) )**2 &
              + ( x3_array(k)*sin( x1_array(i) ) )**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
   call EZspline_isInDomain(spl, k1, k2, k3, x1_array, x2_array, x3_array, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1813,24 +1825,24 @@ subroutine akima3_mix(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
-  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_array,&
-       "akima3_mix__a.nc", ier)
+#ifdef _NETCDF
+  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_array, "akima3_mix_a_.nc", ier)
+  call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_arrayx, "akima3_mix_ax.nc", ier)
 #endif
 
-  write(0,'(a,3f10.6)')' gradient (x, y, z, fx, fy, fz)'
+  write(6,'(a,3f10.6)')' gradient (x, y, z, fx, fy, fz)'
   call EZspline_gradient(spl, x1_point, x2_point, x3_point, &
        df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(10f10.6)') x1_point, x2_point, x3_point, &
+  write(6,'(10f10.6)') x1_point, x2_point, x3_point, &
        df(1), df(2), df(3)
   !compute exact values
   df(1)= -4.0_fp*x3_point*sin(x1_point)*sin(x2_point/2.0_fp)**2
   df(2)= 2.0_fp*(1.0_fp + x3_point*cos(x1_point))*sin(x2_point)
   df(3)= 2.0_fp*x3_point + 2.0_fp*cos(x1_point) - &
        cos(x1_point - x2_point) - cos(x1_point + x2_point)
-  write(0,'(10f10.6)') x1_point, x2_point, x3_point, &
+  write(6,'(10f10.6)') x1_point, x2_point, x3_point, &
        df(1), df(2), df(3)
 
   call EZspline_free(spl, ier)
@@ -1860,7 +1872,7 @@ subroutine pclin1(ier)
   x1 = twopi*(/ (real(i-1,fp)/real(n1-1,fp), i=1, n1) /)
   f = sin(x1)
 
-  write(0,*)'grid size ',n1
+  write(6,*)'grid size ',n1
   call EZlinear_init(spl, n1, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -1875,7 +1887,7 @@ subroutine pclin1(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-  write(0,*)' point interpolation (x, f, f-exact, error)'
+  write(6,*)' point interpolation (x, f, f-exact, error)'
   x1_point = spl%x1(1)
   call EZspline_isInDomain(spl,  x1_point, ier)
   call EZspline_error(ier)
@@ -1884,24 +1896,24 @@ subroutine pclin1(ier)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = twopi/4.0_fp
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
   x1_point = spl%x1(spl%n1)
   call EZspline_interp(spl, x1_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
-  write(0,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
+  write(6,'(3f10.6," ERROR=>",e10.2)') x1_point, f_point, &
        sin(x1_point), f_point-sin(x1_point)
 
-  write(0,*)' cloud interpolation =>"pclin1_.nc" & "pclin1x.nc" (exact)'
+  write(6,*)' cloud interpolation =>"pclin1_.nc" & "pclin1x.nc" (exact)'
   x1_cloud = twopi*(/ (real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   f_cloudx = sin(x1_cloud)
   call EZspline_isInDomain(spl, k1, x1_cloud, ier)
@@ -1912,7 +1924,7 @@ subroutine pclin1(ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF(k1, x1_cloud, f_cloud, 'pclin1_.nc', ier)
   call EZspline_2netCDF(k1, x1_cloud, f_cloudx,'pclin1x.nc', ier)
 #endif
@@ -1959,10 +1971,10 @@ subroutine pclin2(ier)
       x_pt = (1.0_fp + cos( x1(i) ))*cos( x2(j) )
       y_pt = (1.0_fp + cos( x1(i) ))*sin( x2(j) )
       f(i,j) = (x_pt-1.0_fp)**2 + y_pt**2
-    enddo
-  enddo
+    end do
+  end do
 
-  write(0,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
+  write(6,'(" sizes ", i3,"*", i3, "=", i9)') n1, n2, n1*n2
   call EZlinear_init(spl, n1, n2, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -1977,7 +1989,7 @@ subroutine pclin2(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x_pt = (1.0_fp + cos( x1_point ))*cos( x2_point )
@@ -1990,10 +2002,10 @@ subroutine pclin2(ier)
   call EZspline_interp(spl, x1_point, x2_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "pclin2_c.nc" & "pclin2_cx.nc" (exact)'
+  write(6,*)' cloud interpolation => "pclin2_c.nc" & "pclin2_cx.nc" (exact)'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -2008,12 +2020,12 @@ subroutine pclin2(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloud, "pclin2__c.nc", ier)
   call EZspline_2netCDF( k_cloud, x1_cloud, x2_cloud, f_cloudx,"pclin2x_c.nc", ier)
 #endif
 
-  write(0,*)' array interpolation  => "pclin2_a.nc" & "pclin2_ax.nc" (exact)'
+  write(6,*)' array interpolation  => "pclin2_a.nc" & "pclin2_ax.nc" (exact)'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -2025,8 +2037,8 @@ subroutine pclin2(ier)
            cos( x1_array(i) ))*cos( x2_array(j)) - 1.0_fp )**2 &
            + ( (1.0_fp + &
            cos( x1_array(i) ))*sin( x2_array(j) ) )**2 
-    enddo
-  enddo
+    end do
+  end do
   call EZspline_isInDomain(spl,  k1, k2, x1_array, x2_array, ier)
   call EZspline_error(ier)
   if(ier /=0 ) return
@@ -2034,43 +2046,43 @@ subroutine pclin2(ier)
   call EZspline_interp(spl, k1, k2, x1_array, x2_array, f_array, ier)
   call EZspline_error(ier)
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_array, "pclin2__a.nc", ier)
   call EZspline_2netCDF( k1, k2, x1_array, x2_array, f_arrayx,"pclin2x_a.nc", ier)
 #endif
 
-  write(0,*)' point derivative (x, y, fx, fx-exact, error)'
+  write(6,*)' point derivative (x, y, fx, fx-exact, error)'
   fx_pointx = -2.0_fp*(1.0_fp + cos(x1_point) - cos(x2_point))*sin(x1_point)
   call EZspline_derivative(spl, 1, 0, x1_point, x2_point, fx_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fx_point, fx_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fx_point, fx_pointx, &
        fx_point - fx_pointx
 
-  write(0,*)' point derivative (x, y, fy, fy-exact, error)'
+  write(6,*)' point derivative (x, y, fy, fy-exact, error)'
   fy_pointx = 2.0_fp*(1.0_fp + cos(x1_point))*sin(x2_point)
   call EZspline_derivative(spl, 0, 1, x1_point, x2_point, fy_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fy_point, fy_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fy_point, fy_pointx, &
        fy_point - fy_pointx
 
-  write(0,*)' point derivative (x, y, fxy, fxy-exact, error)'
+  write(6,*)' point derivative (x, y, fxy, fxy-exact, error)'
   fxy_pointx = -2.0_fp*sin(x1_point)*sin(x2_point)
   call EZspline_derivative(spl, 1, 1, x1_point, x2_point, fxy_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fxy_point, fxy_pointx, &
+  write(6,'(4f10.6," ERROR=>",e10.2)') x1_point, x2_point, fxy_point, fxy_pointx, &
        fxy_point - fxy_pointx
 
-  write(0,'(a,2f10.6)')' gradient (x, y, fx, fy)'
+  write(6,'(a,2f10.6)')' gradient (x, y, fx, fy)'
   call EZspline_gradient(spl, x1_point, x2_point, &
        df, ier)
   call EZspline_error(ier)
   if(ier /= 0) return  
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, df(1), df(2)
-  write(0,'(4f10.6)') &
+  write(6,'(4f10.6)') &
        x1_point, x2_point, fx_pointx, fy_pointx
 
   call EZspline_free(spl, ier)
@@ -2114,11 +2126,11 @@ subroutine pclin3(ier)
         y_pt = (1.0_fp + x3(k)*cos( x1(i) ))*sin( x2(j) )
         z_pt = x3(k)*sin( x1(i) )
         f(i,j,k) = (x_pt-1.0_fp)**2 + y_pt**2 + z_pt**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
 
-  write(0,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
+  write(6,'(" sizes ", i3,"*", i3, "*", i3, "=", i9)') n1, n2, n3, n1*n2*n3
   call EZlinear_init(spl, n1, n2, n3, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -2134,7 +2146,7 @@ subroutine pclin3(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-  write(0,*)' point interpolation (x, y, z, f, f-exact, error)'
+  write(6,*)' point interpolation (x, y, z, f, f-exact, error)'
   x1_point = spl%x1min + (spl%x1max-spl%x1min)/2.34656_fp
   x2_point = spl%x2min + (spl%x2max-spl%x2min)/1.36482_fp
   x3_point = spl%x3min + (spl%x3max-spl%x3min)/4.93642_fp
@@ -2149,10 +2161,10 @@ subroutine pclin3(ier)
   call EZspline_interp(spl, x1_point, x2_point, x3_point, f_point, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
-  write(0,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
+  write(6,'(5f10.6," ERROR=>",e10.2)') x1_point, x2_point, x3_point, &
        f_point, f_pointx, f_point-f_pointx
 
-  write(0,*)' cloud interpolation => "pclin3_c.nc" & "pclin3_cx.nc"'
+  write(6,*)' cloud interpolation => "pclin3_c.nc" & "pclin3_cx.nc"'
   x1_cloud = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k_cloud-1,fp), i=1, k_cloud) /)
   x2_cloud = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -2170,14 +2182,14 @@ subroutine pclin3(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloud, &
        "pclin3__c.nc", ier)
   call EZspline_2netCDF(k_cloud, x1_cloud, x2_cloud, x3_cloud, f_cloudx, &
        "pclin3_cx.nc", ier)
 #endif
 
-  write(0,*)' array interpolation => "pclin3_a.nc" & "pclin3_ax.nc"'
+  write(6,*)' array interpolation => "pclin3_a.nc" & "pclin3_ax.nc"'
   x1_array = spl%x1min + (spl%x1max-spl%x1min)* &
        (/(real(i-1,fp)/real(k1-1,fp), i=1, k1) /)
   x2_array = spl%x2min + (spl%x2max-spl%x2min)* &
@@ -2193,9 +2205,9 @@ subroutine pclin3(ier)
              + ( (1.0_fp + &
              x3_array(k)*cos( x1_array(i) ))*sin( x2_array(j) ) )**2 &
              + ( x3_array(k)*sin( x1_array(i) ) )**2
-      enddo
-    enddo
-  enddo
+      end do
+    end do
+  end do
   call EZspline_isInDomain(spl, k1, k2, k3, x1_array, x2_array, x3_array, ier)
   call EZspline_error(ier)
   if(ier /= 0) return
@@ -2204,7 +2216,7 @@ subroutine pclin3(ier)
   call EZspline_error(ier)
   if(ier /= 0) return
 
-#ifdef _EZCDF
+#ifdef _NETCDF
   call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_array,&
        "pclin3__a.nc", ier)
   call EZspline_2netCDF(k1, k2, k3, x1_array, x2_array, x3_array, f_arrayx,&

--- a/ezspline/ezspline_test.ref
+++ b/ezspline/ezspline_test.ref
@@ -10,45 +10,37 @@
  derivative imposed are tested, and so are interpolations
  performed on a set of isolated points, on a cloud of points
  and on a grid array of points (grid).
-  
- If you have MATLAB installed on your system, you can view
- the interpolation results saved in the netCDF files *.nc
- provided you also have access to MEXCDF, a netCDF to MATLAB
- interface package freely available at
- http://crusty.er.usgs.gov/~cdenham/MexCDF/nc4ml5.html
- To run the MATLAB script ezspline_test.m, simply type
- "ezspline_test" at the matlab prompt.
  
  > 1-D splines
  
  >> not-a-knot boundary conditions
- grid size  11
+ grid size           11
   point interpolation (x, f, f-exact, error)
   0.000000  0.000000  0.000000 ERROR=>  0.00E+00
   1.570796  0.999740  1.000000 ERROR=> -0.26E-03
-  6.283185  0.000000  0.000000 ERROR=>  0.00E+00
-  cloud interpolation =>"spline1_not.nc" & "spline1_notx.nc" (exact)
+  6.283185 -0.000000 -0.000000 ERROR=>  0.00E+00
+  cloud interpolation =>"spline1_not_.nc" & "spline1_notx.nc" (exact)
  >> periodic boundary conditions
- grid size  11
+ grid size           11
   point interpolation (x, f, f-exact, error)
   0.000000  0.000000  0.000000 ERROR=>  0.00E+00
   1.570796  0.999553  1.000000 ERROR=> -0.45E-03
-  6.283185  0.000000  0.000000 ERROR=>  0.00E+00
-  cloud interpolation => "spline1_per.nc" & "spline1_perx.nc" (exact)
+  6.283185 -0.000000 -0.000000 ERROR=>  0.00E+00
+  cloud interpolation => "spline1_per_.nc" & "spline1_perx.nc" (exact)
  >> 1st derivative boundary conditions
- grid size  11
+ grid size           11
   point interpolation (x, f, f-exact, error)
   0.000000  0.000000  0.000000 ERROR=>  0.00E+00
   1.570796  0.999559  1.000000 ERROR=> -0.44E-03
-  6.283185  0.000000  0.000000 ERROR=>  0.00E+00
+  6.283185 -0.000000 -0.000000 ERROR=>  0.00E+00
   cloud interpolation => "spline1_1st.nc" & "spline_1stx.nc" (exact)
  >> 2nd derivative boundary conditions
- grid size  11
+ grid size           11
   point interpolation (x, f, f-exact, error)
   0.000000  0.000000  0.000000 ERROR=>  0.00E+00
   1.570796  0.999553  1.000000 ERROR=> -0.45E-03
-  6.283185  0.000000  0.000000 ERROR=>  0.00E+00
-  cloud interpolation => "spline1_2nd.nc" & "spline1_2nd.nc" (exact)
+  6.283185 -0.000000 -0.000000 ERROR=>  0.00E+00
+  cloud interpolation => "spline1_2nd.nc" & "spline1_2ndx.nc" (exact)
   point derivative (x, fx, fx-exact, error)
   2.805149 -0.944383 -0.943935 ERROR=> -0.45E-03
   point derivative (x, fxx, fxx-exact, error)
@@ -64,7 +56,7 @@
  sizes  11* 11=      121
   point interpolation (x, y, f, f-exact, error)
   2.677615  4.603673  1.031899  1.034118 ERROR=> -0.22E-02
-  cloud interpolation => "spline2_not_c.nc" & "spline2_not_cx.nc" (exact)
+  cloud interpolation => "spline2_not_c_.nc" & "spline2_not_cx.nc" (exact)
   array interpolation  => "spline2_not_a.nc" & "spline2_not_ax.nc" (exact)
   point derivative (x, y, fx, fx-exact, error)
   2.677615  4.603673 -0.201755 -0.191732 ERROR=> -0.10E-01
@@ -83,14 +75,14 @@
  sizes  11* 11=      121
   point interpolation (x, y, f, f-exact, error)
   2.677615  4.603673  1.031856  1.034118 ERROR=> -0.23E-02
-  cloud interpolation => "spline2_per_c.nc" & "spline2_per_cx.nc"
-  array interpolation "spline2_per_a.nc" & "spline2_per_ax.nc"
+  cloud interpolation => "spline2_per_c_.nc" & "spline2_per_cx.nc"
+  array interpolation "spline2_per_a_.nc" & "spline2_per_ax.nc"
  >> mixed boundary conditions
  sizes  11* 11=      121
   point interpolation (x, y, f, f-exact, error)
   2.677615  4.603673  1.031861  1.034118 ERROR=> -0.23E-02
-  cloud interpolation => "spline2_mix_c.nc" & "spline2_mix_cx.nc"
-  array interpolation "spline2_mix_a.nc" & "spline2_mix_ax.nc"
+  cloud interpolation => "spline2_mix_c_.nc" & "spline2_mix_cx.nc"
+  array interpolation "spline2_mix_a_.nc" & "spline2_mix_ax.nc"
  save spline object in file "spline2.nc"
  
  > 3-D splines
@@ -109,26 +101,26 @@
  gradient (x, y, z, fx, fy, fz)
   2.677615  4.603673  0.202576 -0.200203 -1.624992 -1.577655
   2.677615  4.603673  0.202576 -0.200981 -1.628012 -1.577469
-  cloud interpolation => "spline3_mox__c.nc" & "spline3_mox_cx.nc"
-  array interpolation => "spline3_mox__a.nc" & "spline3_mox_ax.nc"
+  cloud interpolation => "spline3_mox_c_.nc" & "spline3_mox_cx.nc"
+  array interpolation => "spline3_mox_a_.nc" & "spline3_mox_ax.nc"
  
  > 1-D Akima Hermite
  
- grid size  11
+ grid size           11
   point interpolation (x, f, f-exact, error)
   0.000000  0.000000  0.000000 ERROR=>  0.00E+00
   1.570796  1.007185  1.000000 ERROR=>  0.72E-02
-  6.283185  0.000000  0.000000 ERROR=>  0.00E+00
+  6.283185 -0.000000 -0.000000 ERROR=>  0.00E+00
   cloud interpolation =>"akima1__not.nc"
   gradient  (x, fx)
   6.283185  1.114152
   6.283185  1.000000
  >> periodic boundary conditions
- grid size  11
+ grid size           11
   point interpolation (x, f, f-exact, error)
   0.000000  0.000000  0.000000 ERROR=>  0.00E+00
   1.570796  1.007185  1.000000 ERROR=>  0.72E-02
-  6.283185  0.000000  0.000000 ERROR=>  0.00E+00
+  6.283185 -0.000000 -0.000000 ERROR=>  0.00E+00
   gradient  (x, fx)
   6.283185  0.935489
   6.283185  1.000000
@@ -172,11 +164,11 @@
  
  > 1-D Piecewise Linear
  
- grid size  11
+ grid size           11
   point interpolation (x, f, f-exact, error)
   0.000000  0.000000  0.000000 ERROR=>  0.00E+00
   1.570796  0.951057  1.000000 ERROR=> -0.49E-01
-  6.283185  0.000000  0.000000 ERROR=>  0.00E+00
+  6.283185 -0.000000 -0.000000 ERROR=>  0.00E+00
   cloud interpolation =>"pclin1_.nc" & "pclin1x.nc" (exact)
  
  > 2-D Piecewise Linear
@@ -203,4 +195,4 @@
   2.677615  4.603673  0.202576  1.869932  1.856409 ERROR=>  0.14E-01
   cloud interpolation => "pclin3_c.nc" & "pclin3_cx.nc"
   array interpolation => "pclin3_a.nc" & "pclin3_ax.nc"
- *successful end of EZspline test drive*
+  *successful end of EZspline test drive*

--- a/pppl-bashrc
+++ b/pppl-bashrc
@@ -1,5 +1,5 @@
 module purge
-module load git/2.21.0
+module load git
 
 # Specify compiler (GCC, ICC, PGC):
 export COMPILER=ICC
@@ -18,14 +18,10 @@ module load hdf/4.2.14
 module load hdf5-serial/1.10.5
 module load netcdf-c/4.6.3
 module load netcdf-fortran/4.4.5
-export NETCDFLIB=$NETCDF_FORTRAN_HOME
-export NETCDFINC=$NETCDF_FORTRAN_HOME
 
-# You need to set this if you require NetCDF support:
-export EZCDF_HOME=
-if [ ! -z "$EZCDF_HOME" ]; then
-   export EZCDF_FLAGS=" -D_EZCDF"
-   export L_EZCDF=" -L$EZCDF_HOME/lib -lezcdf -L$NETCDFLIB/lib -lnetcdff"
-   export I_EZCDF=" -I$EZCDF_HOME/include -I$NETCDFINC/include"
-   export LD_LIBRARY_PATH=$EZCDF_HOME/lib:$LD_LIBRARY_PATH
+if [ ! -z "$NETCDF_FORTRAN_HOME" ]; then
+   export NETCDF_FLAGS=" -D_NETCDF"
+   export L_NETCDF=" -L$NETCDF_FORTRAN_HOME/lib -lnetcdff"
+   export I_NETCDF=" -I$NETCDF_FORTRAN_HOME/include"
+#  export LD_LIBRARY_PATH=$EZCDF_HOME/lib:$LD_LIBRARY_PATH
 fi


### PR DESCRIPTION
Closes #1.

This pull request removes EZCDF as the NetCDF interface and replaces it with the official NETCDF Fortran 90 interface. All tests passed.